### PR TITLE
#86 Fix thermostat for ios13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 after_success:
 - openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in deploy/pubring.gpg.enc -out
   deploy/pubring.gpg -d

--- a/src/main/java/io/github/hapjava/accessories/TemperatureSensor.java
+++ b/src/main/java/io/github/hapjava/accessories/TemperatureSensor.java
@@ -60,4 +60,14 @@ public interface TemperatureSensor extends HomekitAccessory {
   default TemperatureUnit getTemperatureUnit() {
     return TemperatureUnit.CELSIUS;
   }
+
+  /**
+   * set default temperature unit of the thermostat. this is the unit thermostat use to display
+   * temprature. the homekit interface uses celsius.
+   *
+   * @param unit the temperature unit of the thermostat.
+   */
+  default void setTemperatureUnit(TemperatureUnit unit) {
+    // override depending on the thermostat if required.
+  }
 }

--- a/src/main/java/io/github/hapjava/accessories/TemperatureSensor.java
+++ b/src/main/java/io/github/hapjava/accessories/TemperatureSensor.java
@@ -70,4 +70,14 @@ public interface TemperatureSensor extends HomekitAccessory {
   default void setTemperatureUnit(TemperatureUnit unit) {
     // override depending on the thermostat if required.
   }
+
+  /**
+   * subscribe to unit changes.
+   *
+   * @param callback callback
+   */
+  default void subscribeTemperatureUnit(final HomekitCharacteristicChangeCallback callback) {}
+
+  /** unsubscribe from unit changes. */
+  default void unsubscribeTemperatureUnit() {}
 }

--- a/src/main/java/io/github/hapjava/impl/characteristics/thermostat/TemperatureUnitsCharacteristic.java
+++ b/src/main/java/io/github/hapjava/impl/characteristics/thermostat/TemperatureUnitsCharacteristic.java
@@ -1,25 +1,36 @@
 package io.github.hapjava.impl.characteristics.thermostat;
 
+import io.github.hapjava.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.accessories.properties.TemperatureUnit;
 import io.github.hapjava.accessories.thermostat.BasicThermostat;
 import io.github.hapjava.characteristics.EnumCharacteristic;
+import io.github.hapjava.characteristics.EventableCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
-public class TemperatureUnitsCharacteristic extends EnumCharacteristic {
+public class TemperatureUnitsCharacteristic extends EnumCharacteristic
+    implements EventableCharacteristic {
 
   private final BasicThermostat thermostat;
 
   public TemperatureUnitsCharacteristic(BasicThermostat thermostat) {
-    super("00000036-0000-1000-8000-0026BB765291", false, true, "The temperature unit", 1);
+    super("00000036-0000-1000-8000-0026BB765291", true, true, "The temperature unit", 1);
     this.thermostat = thermostat;
   }
 
   @Override
   protected void setValue(Integer value) throws Exception {
-    // Not writable
+    thermostat.setTemperatureUnit(
+        value == 1 ? TemperatureUnit.FAHRENHEIT : TemperatureUnit.CELSIUS);
   }
 
   @Override
   protected CompletableFuture<Integer> getValue() {
     return CompletableFuture.completedFuture(thermostat.getTemperatureUnit().getCode());
   }
+
+  @Override
+  public void subscribe(final HomekitCharacteristicChangeCallback callback) {}
+
+  @Override
+  public void unsubscribe() {}
 }

--- a/src/main/java/io/github/hapjava/impl/characteristics/thermostat/TemperatureUnitsCharacteristic.java
+++ b/src/main/java/io/github/hapjava/impl/characteristics/thermostat/TemperatureUnitsCharacteristic.java
@@ -29,8 +29,12 @@ public class TemperatureUnitsCharacteristic extends EnumCharacteristic
   }
 
   @Override
-  public void subscribe(final HomekitCharacteristicChangeCallback callback) {}
+  public void subscribe(final HomekitCharacteristicChangeCallback callback) {
+    thermostat.subscribeTemperatureUnit(callback);
+  }
 
   @Override
-  public void unsubscribe() {}
+  public void unsubscribe() {
+    thermostat.unsubscribeTemperatureUnit();
+  }
 }


### PR DESCRIPTION
set target temperature is not working in ios13 as ios13 expected temperature unit (celsius, fahrenheit) to be changeable.  the temperature unit is used in homekit only for displaying purposes. at the protocol level the celsius is used as basis.

this patch makes temperature unit changeable.