### PR TITLE
fix the names of the garage door characteristics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 after_success:
 - openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in deploy/pubring.gpg.enc -out
   deploy/pubring.gpg -d

--- a/src/main/java/io/github/hapjava/impl/characteristics/garage/CurrentDoorStateCharacteristic.java
+++ b/src/main/java/io/github/hapjava/impl/characteristics/garage/CurrentDoorStateCharacteristic.java
@@ -2,7 +2,6 @@ package io.github.hapjava.impl.characteristics.garage;
 
 import io.github.hapjava.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.accessories.GarageDoor;
-import io.github.hapjava.accessories.properties.DoorState;
 import io.github.hapjava.characteristics.EnumCharacteristic;
 import io.github.hapjava.characteristics.EventableCharacteristic;
 import java.util.concurrent.CompletableFuture;
@@ -13,27 +12,27 @@ public class CurrentDoorStateCharacteristic extends EnumCharacteristic
   private final GarageDoor door;
 
   public CurrentDoorStateCharacteristic(GarageDoor door) {
-    super("00000032-0000-1000-8000-0026BB765291", true, true, "Target Door State", 1);
+    super("0000000E-0000-1000-8000-0026BB765291", false, true, "Current Door State", 4);
     this.door = door;
   }
 
   @Override
   protected void setValue(Integer value) throws Exception {
-    door.setTargetDoorState(DoorState.fromCode(value));
+    // Read Only
   }
 
   @Override
   protected CompletableFuture<Integer> getValue() {
-    return door.getTargetDoorState().thenApply(s -> s.getCode());
+    return door.getCurrentDoorState().thenApply(s -> s.getCode());
   }
 
   @Override
   public void subscribe(HomekitCharacteristicChangeCallback callback) {
-    door.subscribeTargetDoorState(callback);
+    door.subscribeCurrentDoorState(callback);
   }
 
   @Override
   public void unsubscribe() {
-    door.unsubscribeTargetDoorState();
+    door.unsubscribeCurrentDoorState();
   }
 }

--- a/src/main/java/io/github/hapjava/impl/characteristics/garage/TargetDoorStateCharacteristic.java
+++ b/src/main/java/io/github/hapjava/impl/characteristics/garage/TargetDoorStateCharacteristic.java
@@ -2,6 +2,7 @@ package io.github.hapjava.impl.characteristics.garage;
 
 import io.github.hapjava.HomekitCharacteristicChangeCallback;
 import io.github.hapjava.accessories.GarageDoor;
+import io.github.hapjava.accessories.properties.DoorState;
 import io.github.hapjava.characteristics.EnumCharacteristic;
 import io.github.hapjava.characteristics.EventableCharacteristic;
 import java.util.concurrent.CompletableFuture;
@@ -12,27 +13,27 @@ public class TargetDoorStateCharacteristic extends EnumCharacteristic
   private final GarageDoor door;
 
   public TargetDoorStateCharacteristic(GarageDoor door) {
-    super("0000000E-0000-1000-8000-0026BB765291", false, true, "Current Door State", 4);
+    super("00000032-0000-1000-8000-0026BB765291", true, true, "Target Door State", 1);
     this.door = door;
   }
 
   @Override
   protected void setValue(Integer value) throws Exception {
-    // Read Only
+    door.setTargetDoorState(DoorState.fromCode(value));
   }
 
   @Override
   protected CompletableFuture<Integer> getValue() {
-    return door.getCurrentDoorState().thenApply(s -> s.getCode());
+    return door.getTargetDoorState().thenApply(s -> s.getCode());
   }
 
   @Override
   public void subscribe(HomekitCharacteristicChangeCallback callback) {
-    door.subscribeCurrentDoorState(callback);
+    door.subscribeTargetDoorState(callback);
   }
 
   @Override
   public void unsubscribe() {
-    door.unsubscribeCurrentDoorState();
+    door.unsubscribeTargetDoorState();
   }
 }


### PR DESCRIPTION
the names for current and target state of the garage door were swapped. e.g. targetDoorState had no "setState" method.