### PR TITLE
#93 Fix discoverability & pairing with ios13

### DIFF
--- a/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
+++ b/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
@@ -66,6 +66,8 @@ class HttpSession {
   }
 
   public HttpResponse handleAuthenticatedRequest(HttpRequest request) throws IOException {
+    advertiser.setDiscoverable(
+        false); // brigde is already binded and should not be discoverable anymore
     try {
       switch (request.getUri()) {
         case "/accessories":

--- a/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
+++ b/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
@@ -101,7 +101,7 @@ class HttpSession {
     if (pairingManager == null) {
       synchronized (HttpSession.class) {
         if (pairingManager == null) {
-          pairingManager = new PairingManager(authInfo, registry, advertiser);
+          pairingManager = new PairingManager(authInfo, registry);
         }
       }
     }

--- a/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
+++ b/src/main/java/io/github/hapjava/impl/connections/HttpSession.java
@@ -67,7 +67,7 @@ class HttpSession {
 
   public HttpResponse handleAuthenticatedRequest(HttpRequest request) throws IOException {
     advertiser.setDiscoverable(
-        false); // brigde is already binded and should not be discoverable anymore
+        false); // brigde is already bound and should not be discoverable anymore
     try {
       switch (request.getUri()) {
         case "/accessories":

--- a/src/main/java/io/github/hapjava/impl/json/AccessoryController.java
+++ b/src/main/java/io/github/hapjava/impl/json/AccessoryController.java
@@ -81,8 +81,7 @@ public class AccessoryController {
         .thenApply(
             v -> {
               JsonArrayBuilder jsonCharacteristics = Json.createArrayBuilder();
-              characteristicFutures
-                  .stream()
+              characteristicFutures.stream()
                   .map(future -> future.join())
                   .forEach(c -> jsonCharacteristics.add(c));
               builder.add("characteristics", jsonCharacteristics);

--- a/src/main/java/io/github/hapjava/impl/pairing/FinalPairHandler.java
+++ b/src/main/java/io/github/hapjava/impl/pairing/FinalPairHandler.java
@@ -3,7 +3,6 @@ package io.github.hapjava.impl.pairing;
 import io.github.hapjava.HomekitAuthInfo;
 import io.github.hapjava.impl.crypto.*;
 import io.github.hapjava.impl.http.HttpResponse;
-import io.github.hapjava.impl.jmdns.JmdnsHomekitAdvertiser;
 import io.github.hapjava.impl.pairing.PairSetupRequest.Stage3Request;
 import io.github.hapjava.impl.pairing.TypeLengthValueUtils.DecodeResult;
 import io.github.hapjava.impl.pairing.TypeLengthValueUtils.Encoder;
@@ -16,14 +15,12 @@ class FinalPairHandler {
 
   private final byte[] k;
   private final HomekitAuthInfo authInfo;
-  private final JmdnsHomekitAdvertiser advertiser;
 
   private byte[] hkdf_enc_key;
 
-  public FinalPairHandler(byte[] k, HomekitAuthInfo authInfo, JmdnsHomekitAdvertiser advertiser) {
+  public FinalPairHandler(byte[] k, HomekitAuthInfo authInfo) {
     this.k = k;
     this.authInfo = authInfo;
-    this.advertiser = advertiser;
   }
 
   public HttpResponse handle(PairSetupRequest req) throws Exception {
@@ -66,7 +63,6 @@ class FinalPairHandler {
       throw new Exception("Invalid signature");
     }
     authInfo.createUser(authInfo.getMac() + new String(username, StandardCharsets.UTF_8), ltpk);
-    advertiser.setDiscoverable(false);
     return createResponse();
   }
 

--- a/src/main/java/io/github/hapjava/impl/pairing/PairingManager.java
+++ b/src/main/java/io/github/hapjava/impl/pairing/PairingManager.java
@@ -4,7 +4,6 @@ import io.github.hapjava.HomekitAuthInfo;
 import io.github.hapjava.impl.HomekitRegistry;
 import io.github.hapjava.impl.http.HttpRequest;
 import io.github.hapjava.impl.http.HttpResponse;
-import io.github.hapjava.impl.jmdns.JmdnsHomekitAdvertiser;
 import io.github.hapjava.impl.responses.NotFoundResponse;
 import io.github.hapjava.impl.responses.UnauthorizedResponse;
 import org.slf4j.Logger;
@@ -16,15 +15,12 @@ public class PairingManager {
 
   private final HomekitAuthInfo authInfo;
   private final HomekitRegistry registry;
-  private final JmdnsHomekitAdvertiser advertiser;
 
   private SrpHandler srpHandler;
 
-  public PairingManager(
-      HomekitAuthInfo authInfo, HomekitRegistry registry, JmdnsHomekitAdvertiser advertiser) {
+  public PairingManager(HomekitAuthInfo authInfo, HomekitRegistry registry) {
     this.authInfo = authInfo;
     this.registry = registry;
-    this.advertiser = advertiser;
   }
 
   public HttpResponse handle(HttpRequest httpRequest) throws Exception {
@@ -54,7 +50,7 @@ public class PairingManager {
         logger.warn("Received unexpected stage 3 request for " + registry.getLabel());
         return new UnauthorizedResponse();
       } else {
-        FinalPairHandler handler = new FinalPairHandler(srpHandler.getK(), authInfo, advertiser);
+        FinalPairHandler handler = new FinalPairHandler(srpHandler.getK(), authInfo);
         try {
           return handler.handle(req);
         } catch (Exception e) {


### PR DESCRIPTION
ios13 evaluate sdiscoverability (sf flag) differently than older ios and stop pairing process if this flag changes (see issue #93). this PR fix it by keeping discoverability true 