### PR TITLE
add support for linked services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
     * `services` package consists of services, which grouping characteristics. e.g. `WindowCoveringService` defines mandatory and optional characteristics for a window covering service as it is defined in HAP spec.
     * `server` package consists classes to run HomeKit server and handle communication
 * the process is following: client, e.g. openHAB bindings, extends accessory classes, e.g. `WindowCoveringAccessory` and implements all required methods. WindowCoveringAccessory is linked already to WindowCoveringService, that in turn is link to single characteristics. 
+* linked service support
 
 # HAP-Java 1.1.5
 

--- a/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
@@ -4,7 +4,12 @@ import io.github.hapjava.accessories.HomekitAccessory;
 import io.github.hapjava.characteristics.Characteristic;
 import io.github.hapjava.services.Service;
 import io.github.hapjava.services.impl.AccessoryInformationService;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +20,7 @@ public class HomekitRegistry {
 
   private final String label;
   private final Map<Integer, HomekitAccessory> accessories;
-  private final Map<HomekitAccessory, List<Service>> services = new HashMap<>();
+  private final Map<HomekitAccessory, Map<Integer, Service>> services = new HashMap<>();
   private final Map<HomekitAccessory, Map<Integer, Characteristic>> characteristics =
       new HashMap<>();
   private boolean isAllowUnauthenticatedRequests = false;
@@ -35,21 +40,26 @@ public class HomekitRegistry {
       try {
         newServices = new ArrayList<>(2);
         newServices.add(new AccessoryInformationService(accessory));
-        newServices.addAll(accessory.getServices());
+        for (Service service : accessory.getServices()) {
+          newServices.add(service);
+          newServices.addAll(service.getLinkedServices());
+        }
       } catch (Exception e) {
         logger.warn("Could not instantiate services for accessory " + accessory.getName(), e);
-        services.put(accessory, Collections.emptyList());
+        services.put(accessory, Collections.emptyMap());
         continue;
       }
-      Map<Integer, Characteristic> newCharacteristics = new HashMap<>();
-      services.put(accessory, newServices);
+
+      Map<Integer, Characteristic> newCharacteristicsByInterfaceId = new HashMap<>();
+      Map<Integer, Service> newServicesByInterfaceId = new HashMap<>();
       for (Service service : newServices) {
-        iid++;
+        newServicesByInterfaceId.put(++iid, service);
         for (Characteristic characteristic : service.getCharacteristics()) {
-          newCharacteristics.put(++iid, characteristic);
+          newCharacteristicsByInterfaceId.put(++iid, characteristic);
         }
       }
-      characteristics.put(accessory, newCharacteristics);
+      services.put(accessory, newServicesByInterfaceId);
+      characteristics.put(accessory, newCharacteristicsByInterfaceId);
     }
   }
 
@@ -61,8 +71,8 @@ public class HomekitRegistry {
     return accessories.values();
   }
 
-  public List<Service> getServices(Integer aid) {
-    return Collections.unmodifiableList(services.get(accessories.get(aid)));
+  public Map<Integer, Service> getServices(Integer aid) {
+    return Collections.unmodifiableMap(services.get(accessories.get(aid)));
   }
 
   public Map<Integer, Characteristic> getCharacteristics(Integer aid) {

--- a/src/main/java/io/github/hapjava/services/Service.java
+++ b/src/main/java/io/github/hapjava/services/Service.java
@@ -29,4 +29,11 @@ public interface Service {
    *     ########-####-####-####-############.
    */
   String getType();
+
+  /**
+   * List of all the services to which the service links
+   *
+   * @return the list of linked services.
+   */
+  List<Service> getLinkedServices();
 }

--- a/src/main/java/io/github/hapjava/services/impl/AbstractServiceImpl.java
+++ b/src/main/java/io/github/hapjava/services/impl/AbstractServiceImpl.java
@@ -12,6 +12,7 @@ abstract class AbstractServiceImpl implements Service {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final String type;
   private final List<Characteristic> characteristics = new LinkedList<>();
+  private final List<Service> linkedServices = new LinkedList<>();
 
   /** @param type unique UUID of the service according to HAP specification. */
   public AbstractServiceImpl(String type) {
@@ -28,7 +29,16 @@ abstract class AbstractServiceImpl implements Service {
     return type;
   }
 
+  @Override
+  public List<Service> getLinkedServices() {
+    return Collections.unmodifiableList(linkedServices);
+  }
+
   public void addCharacteristic(Characteristic characteristic) {
     this.characteristics.add(characteristic);
+  }
+
+  public void addLinkedService(Service service) {
+    this.linkedServices.add(service);
   }
 }


### PR DESCRIPTION
Some services require linked services to work, for example, the Television service which requires each input to be a linked service.
With this change, support to link services is added, though it's not used in any existing service, as they don't need linking. But I verified the functionality using my own Television service, which is not yet production-ready.

This change also centralizes the generation of interface ids. They are now only generated in the registry. 
We were previously also generating them in the accessory controller, relying on an identical processing sequence.

This is implementing the issue https://github.com/hap-java/HAP-Java/issues/104 and replacing PR https://github.com/hap-java/HAP-Java/pull/105. 
The author seems to have abandoned the PR and I personally also think that linking accessories rather than services is not the right level.

# Pull Request Checklist

Please confirm that you've done the following when opening a new pull request:

  - [X] For fixes and other improvements, please reference the GitHub issue that your change addresses.
  - [X] For fixes, optimizations and new features, please add an entry to the CHANGES.md file.
  - [X] Run mvn compile before committing, so that the auto-code formatter will format your changes consistently with the rest of the project.

