### PR TITLE
port of #68 PR on jmDNS to latest code base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 	<properties>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<netty.version>4.1.42.Final</netty.version>
-
 	</properties>
 
 	<licenses>
@@ -135,9 +134,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.jmdns</groupId>
+			<groupId>org.jmdns</groupId>
 			<artifactId>jmdns</artifactId>
-			<version>3.4.1</version>
+			<version>3.5.6</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/io/github/hapjava/server/impl/HomekitRoot.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitRoot.java
@@ -9,6 +9,7 @@ import io.github.hapjava.server.impl.connections.SubscriptionManager;
 import io.github.hapjava.server.impl.jmdns.JmdnsHomekitAdvertiser;
 import java.io.IOException;
 import java.net.InetAddress;
+import javax.jmdns.JmDNS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,11 @@ public class HomekitRoot {
     this.authInfo = authInfo;
     this.label = label;
     this.registry = new HomekitRegistry(label);
+  }
+
+  HomekitRoot(String label, HomekitWebHandler webHandler, JmDNS jmdns, HomekitAuthInfo authInfo)
+      throws IOException {
+    this(label, webHandler, authInfo, new JmdnsHomekitAdvertiser(jmdns));
   }
 
   /**

--- a/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.ExecutionException;
+import javax.jmdns.JmDNS;
 
 /**
  * A server for exposing standalone HomeKit accessory (as opposed to a Bridge accessory which
@@ -27,6 +28,16 @@ public class HomekitStandaloneAccessoryServer {
       HomekitAuthInfo authInfo)
       throws UnknownHostException, IOException, ExecutionException, InterruptedException {
     root = new HomekitRoot(accessory.getName().get(), webHandler, localhost, authInfo);
+    root.addAccessory(accessory);
+  }
+
+  HomekitStandaloneAccessoryServer(
+      HomekitAccessory accessory,
+      HomekitWebHandler webHandler,
+      JmDNS jmdns,
+      HomekitAuthInfo authInfo)
+      throws UnknownHostException, IOException, ExecutionException, InterruptedException {
+    root = new HomekitRoot(accessory.getName().get(), webHandler, jmdns, authInfo);
     root.addAccessory(accessory);
   }
 

--- a/src/main/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiser.java
+++ b/src/main/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiser.java
@@ -24,6 +24,10 @@ public class JmdnsHomekitAdvertiser {
   private int port;
   private int configurationIndex;
 
+  public JmdnsHomekitAdvertiser(JmDNS jmdns) {
+    this.jmdns = jmdns;
+  }
+
   public JmdnsHomekitAdvertiser(InetAddress localAddress) throws UnknownHostException, IOException {
     jmdns = JmDNS.create(localAddress);
   }
@@ -53,7 +57,7 @@ public class JmdnsHomekitAdvertiser {
   }
 
   public synchronized void stop() {
-    jmdns.unregisterAllServices();
+    unregisterService();
   }
 
   public synchronized void setDiscoverable(boolean discoverable) throws IOException {
@@ -61,7 +65,7 @@ public class JmdnsHomekitAdvertiser {
       this.discoverable = discoverable;
       if (isAdvertising) {
         logger.trace("Re-creating service due to change in discoverability to " + discoverable);
-        jmdns.unregisterAllServices();
+        unregisterService();
         registerService();
       }
     }
@@ -72,14 +76,22 @@ public class JmdnsHomekitAdvertiser {
       this.configurationIndex = revision;
       if (isAdvertising) {
         logger.trace("Re-creating service due to change in configuration index to " + revision);
-        jmdns.unregisterAllServices();
+        unregisterService();
         registerService();
       }
     }
   }
 
+  private void unregisterService() {
+    jmdns.unregisterService(buildServiceInfo());
+  }
+
   private void registerService() throws IOException {
     logger.info("Registering " + SERVICE_TYPE + " on port " + port);
+    jmdns.registerService(buildServiceInfo());
+  }
+
+  private ServiceInfo buildServiceInfo() {
     Map<String, String> props = new HashMap<>();
     props.put("sf", discoverable ? "1" : "0");
     props.put("id", mac);
@@ -88,6 +100,6 @@ public class JmdnsHomekitAdvertiser {
     props.put("s#", "1");
     props.put("ff", "0");
     props.put("ci", "1");
-    jmdns.registerService(ServiceInfo.create(SERVICE_TYPE, label, port, 1, 1, props));
+    return ServiceInfo.create(SERVICE_TYPE, label, port, 1, 1, props);
   }
 }


### PR DESCRIPTION
porting the old PR with jmDNS enhancements to latest code base and updating jmDNS to latest stable version, which is 3.5.6

Signed-off-by: Eugen Freiter <freiter@gmx.de>
