### PR TITLE
fix typo in enum value

### DIFF
--- a/src/main/java/io/github/hapjava/characteristics/impl/garagedoor/CurrentDoorStateEnum.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/garagedoor/CurrentDoorStateEnum.java
@@ -15,7 +15,7 @@ public enum CurrentDoorStateEnum implements CharacteristicEnum {
   CLOSED(1),
   OPENING(2),
   CLOSING(3),
-  SOPPED(4);
+  STOPPED(4);
 
   private static final Map<Integer, CurrentDoorStateEnum> reverse;
 


### PR DESCRIPTION
Fixes #131

Simple typo in `CurrentDoorStateEnum`: `SOPPED` should be `STOPPED`
