### PR TITLE
Remove event parameter

### DIFF
--- a/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
@@ -113,7 +113,6 @@ public abstract class BaseCharacteristic<T> implements Characteristic, Eventable
                       .add("type", shortType)
                       .add("perms", perms.build())
                       .add("format", format)
-                      .add("ev", false)
                       .add("description", description);
               if (isReadable) setJsonValue(builder, value);
               return builder;


### PR DESCRIPTION
"event" is payload parameter used to subscribe or unsubscribe to/from event notification. e.g. controller sends "event:true" to the HAP accessory if it wants to get event notifications.

 it is unclear from the specification whether it should be sent with accessory description or not. it is marked as optional.  Java-HAP was always sending it with the value "false".

however, the recent version of home app stops working if this parameter is in the payload for some accessory types, e.g. ColorTemperature. (reported here https://github.com/openhab/openhab-addons/issues/9799 and here https://community.openhab.org/t/homekit-color-temperature-with-hue-bulbs/105658). I could also re-produce this behaviour. 

this PR removes "event" parameter from the payload. 