### PR TITLE
extend support for custom min/max/step to further characteristics

### DIFF
--- a/src/main/java/io/github/hapjava/accessories/LightSensorAccessory.java
+++ b/src/main/java/io/github/hapjava/accessories/LightSensorAccessory.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.lightsensor.CurrentAmbientLightLevelCharacteristic;
 import io.github.hapjava.services.Service;
 import io.github.hapjava.services.impl.LightSensorService;
 import java.util.Collection;
@@ -30,6 +31,36 @@ public interface LightSensorAccessory extends HomekitAccessory {
 
   /** Unsubscribes from changes in the current ambient light level. */
   void unsubscribeCurrentAmbientLightLevel();
+
+  /**
+   * return the min value for current ambient light level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min current ambient light level
+   */
+  default double getMinCurrentAmbientLightLevel() {
+    return CurrentAmbientLightLevelCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for current ambient light level. overwrite if you want to change the
+   * default value.
+   *
+   * @return max current ambient light level
+   */
+  default double getMaxCurrentAmbientLightLevel() {
+    return CurrentAmbientLightLevelCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for current ambient light level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step current ambient light level
+   */
+  default double getMinStepCurrentAmbientLightLevel() {
+    return CurrentAmbientLightLevelCharacteristic.DEFAULT_STEP;
+  }
 
   @Override
   default Collection<Service> getServices() {

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithCarbonDioxideLevel.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithCarbonDioxideLevel.java
@@ -1,6 +1,8 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.carbondioxidesensor.CarbonDioxideLevelCharacteristic;
+import io.github.hapjava.characteristics.impl.carbondioxidesensor.CarbonDioxidePeakLevelCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with carbon dioxide level and peak level characteristic. */
@@ -19,6 +21,66 @@ public interface AccessoryWithCarbonDioxideLevel {
    * @return a future that will contain the carbon dioxide level as a value between 0 and 100000
    */
   CompletableFuture<Double> getCarbonDioxideLevel();
+
+  /**
+   * return the min value for carbon dioxide level. overwrite if you want to change the default
+   * value.
+   *
+   * @return min carbon dioxide level
+   */
+  default double getMinCarbonDioxideLevel() {
+    return CarbonDioxideLevelCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for carbon dioxide level. overwrite if you want to change the default
+   * value.
+   *
+   * @return max carbon dioxide level
+   */
+  default double getMaxCarbonDioxideLevel() {
+    return CarbonDioxideLevelCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for carbon dioxide level. overwrite if you want to change the default
+   * value.
+   *
+   * @return min step carbon dioxide level
+   */
+  default double getMinStepCarbonDioxideLevel() {
+    return CarbonDioxideLevelCharacteristic.DEFAULT_STEP;
+  }
+
+  /**
+   * return the min value for carbon dioxide peak level. overwrite if you want to change the default
+   * value.
+   *
+   * @return min carbon dioxide peak level
+   */
+  default double getMinCarbonDioxidePeakLevel() {
+    return CarbonDioxidePeakLevelCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for carbon dioxide peak level. overwrite if you want to change the default
+   * value.
+   *
+   * @return max carbon dioxide peak level
+   */
+  default double getMaxCarbonDioxidePeakLevel() {
+    return CarbonDioxidePeakLevelCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for carbon dioxide peak level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step carbon dioxide peak level
+   */
+  default double getMinStepCarbonDioxidePeakLevel() {
+    return CarbonDioxidePeakLevelCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in the carbon dioxide level.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithCarbonMonoxideLevel.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithCarbonMonoxideLevel.java
@@ -1,9 +1,11 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.carbonmonoxidesensor.CarbonMonoxideLevelCharacteristic;
+import io.github.hapjava.characteristics.impl.carbonmonoxidesensor.CarbonMonoxidePeakLevelCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
-/** Accessory with carbon dioxide level and peak level characteristic. */
+/** Accessory with carbon monoxide level and peak level characteristic. */
 public interface AccessoryWithCarbonMonoxideLevel {
 
   /**
@@ -19,6 +21,66 @@ public interface AccessoryWithCarbonMonoxideLevel {
    * @return a future that will contain the carbon monoxide level as a value between 0 and 100000
    */
   CompletableFuture<Double> getCarbonMonoxideLevel();
+
+  /**
+   * return the min value for carbon monoxide level. overwrite if you want to change the default
+   * value.
+   *
+   * @return min carbon monoxide level
+   */
+  default double getMinCarbonMonoxideLevel() {
+    return CarbonMonoxideLevelCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for carbon monoxide level. overwrite if you want to change the default
+   * value.
+   *
+   * @return max carbon monoxide level
+   */
+  default double getMaxCarbonMonoxideLevel() {
+    return CarbonMonoxideLevelCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for carbon monoxide level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step carbon monoxide level
+   */
+  default double getMinStepCarbonMonoxideLevel() {
+    return CarbonMonoxideLevelCharacteristic.DEFAULT_STEP;
+  }
+
+  /**
+   * return the min value for carbon monoxide peak level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min carbon monoxide peak level
+   */
+  default double getMinCarbonMonoxidePeakLevel() {
+    return CarbonMonoxidePeakLevelCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for carbon monoxide peak level. overwrite if you want to change the
+   * default value.
+   *
+   * @return max carbon monoxide peak level
+   */
+  default double getMaxCarbonMonoxidePeakLevel() {
+    return CarbonMonoxidePeakLevelCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for carbon monoxide peak level. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step carbon monoxide peak level
+   */
+  default double getMinStepCarbonMonoxidePeakLevel() {
+    return CarbonMonoxidePeakLevelCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in the carbon monoxide level.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithColorTemperature.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithColorTemperature.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.lightbulb.ColorTemperatureCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with color temperature. */
@@ -21,6 +22,24 @@ public interface AccessoryWithColorTemperature {
    * @throws Exception when the brightness cannot be set
    */
   CompletableFuture<Void> setColorTemperature(Integer value) throws Exception;
+
+  /**
+   * return the min value for color temperature. overwrite if you want to change the default value.
+   *
+   * @return min color temperature
+   */
+  default int getMinColorTemperature() {
+    return ColorTemperatureCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for color temperature. overwrite if you want to change the default value.
+   *
+   * @return max color temperature
+   */
+  default int getMaxColorTemperature() {
+    return ColorTemperatureCharacteristic.DEFAULT_MAX_VALUE;
+  }
 
   /**
    * Subscribes to changes in color temperature.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithDuration.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithDuration.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.valve.SetDurationCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with duration characteristic. */
@@ -12,6 +13,24 @@ public interface AccessoryWithDuration {
    * @return a future with the value
    */
   CompletableFuture<Integer> getSetDuration();
+
+  /**
+   * return the min value for duration. overwrite if you want to change the default value.
+   *
+   * @return min remaining duration
+   */
+  default int getMinDuration() {
+    return SetDurationCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for duration. overwrite if you want to change the default value.
+   *
+   * @return max duration
+   */
+  default int getMaxDuration() {
+    return SetDurationCharacteristic.DEFAULT_MAX_VALUE;
+  }
 
   /**
    * Sets the duration for which the service should run.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithNitrogenDioxideDensity.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithNitrogenDioxideDensity.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.NitrogenDioxideDensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with nitrogen dioxide density characteristic. */
@@ -12,6 +13,36 @@ public interface AccessoryWithNitrogenDioxideDensity {
    * @return a future with the nitrogen dioxide density
    */
   CompletableFuture<Double> getNitrogenDioxideDensity();
+
+  /**
+   * return the min value for nitrogen dioxide density. overwrite if you want to change the default
+   * value.
+   *
+   * @return min nitrogen dioxide density
+   */
+  default double getMinNitrogenDioxideDensity() {
+    return NitrogenDioxideDensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for nitrogen dioxide density. overwrite if you want to change the default
+   * value.
+   *
+   * @return max nitrogen dioxide density
+   */
+  default double getMaxNitrogenDioxideDensity() {
+    return NitrogenDioxideDensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for nitrogen dioxide density. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step nitrogen dioxide density
+   */
+  default double getMinStepNitrogenDioxideDensity() {
+    return NitrogenDioxideDensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in nitrogen dioxide density.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithOzoneDensity.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithOzoneDensity.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.OzoneDensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with Ozone Density characteristic. */
@@ -12,6 +13,33 @@ public interface AccessoryWithOzoneDensity {
    * @return a future with the ozone density
    */
   CompletableFuture<Double> getOzoneDensity();
+
+  /**
+   * return the min value for ozone density. overwrite if you want to change the default value.
+   *
+   * @return min ozone density
+   */
+  default double getMinOzoneDensity() {
+    return OzoneDensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for ozone density. overwrite if you want to change the default value.
+   *
+   * @return max ozone density
+   */
+  default double getMaxOzoneDensity() {
+    return OzoneDensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for ozone density. overwrite if you want to change the default value.
+   *
+   * @return min step ozone density
+   */
+  default double getMinStepOzoneDensity() {
+    return OzoneDensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in ozone density.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithPM10Density.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithPM10Density.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.PM10DensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with PM10 Density characteristic. */
@@ -12,6 +13,33 @@ public interface AccessoryWithPM10Density {
    * @return a future with the PM10 density
    */
   CompletableFuture<Double> getPM10Density();
+
+  /**
+   * return the min value for PM10 density. overwrite if you want to change the default value.
+   *
+   * @return min PM10 density
+   */
+  default double getMinPM10Density() {
+    return PM10DensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for PM10 density. overwrite if you want to change the default value.
+   *
+   * @return max PM10 density
+   */
+  default double getMaxPM10Density() {
+    return PM10DensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for PM10 density. overwrite if you want to change the default value.
+   *
+   * @return min step PM10 density
+   */
+  default double getMinStepPM10Density() {
+    return PM10DensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in PM10 density.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithPM25Density.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithPM25Density.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.PM25DensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with PM25 Density characteristic. */
@@ -12,6 +13,33 @@ public interface AccessoryWithPM25Density {
    * @return a future with the PM25 density
    */
   CompletableFuture<Double> getPM25Density();
+
+  /**
+   * return the min value for PM25 density. overwrite if you want to change the default value.
+   *
+   * @return min PM25 density
+   */
+  default double getMinPM25Density() {
+    return PM25DensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for PM25 density. overwrite if you want to change the default value.
+   *
+   * @return max PM25 density
+   */
+  default double getMaxPM25Density() {
+    return PM25DensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for PM25 density. overwrite if you want to change the default value.
+   *
+   * @return min step PM25 density
+   */
+  default double getMinStepPM25Density() {
+    return PM25DensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in PM25 density.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithRemainingDuration.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithRemainingDuration.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.valve.RemainingDurationCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -16,6 +17,24 @@ public interface AccessoryWithRemainingDuration {
    * @return a future with the duration in seconds
    */
   CompletableFuture<Integer> getRemainingDuration();
+
+  /**
+   * return the min value for remaining duration. overwrite if you want to change the default value.
+   *
+   * @return min remaining duration
+   */
+  default int getMinRemainingDuration() {
+    return RemainingDurationCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for remaining duration. overwrite if you want to change the default value.
+   *
+   * @return max remaining duration
+   */
+  default int getMaxRemainingDuration() {
+    return RemainingDurationCharacteristic.DEFAULT_MAX_VALUE;
+  }
 
   /**
    * Subscribes to changes in the duration; note it is not necessary to emit a change every second,

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithSulphurDioxideDensity.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithSulphurDioxideDensity.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.SulphurDioxideDensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with sulphur dioxide density characteristic. */
@@ -12,6 +13,36 @@ public interface AccessoryWithSulphurDioxideDensity {
    * @return a future with the sulphur dioxide density
    */
   CompletableFuture<Double> getSulphurDioxideDensity();
+
+  /**
+   * return the min value for sulphur dioxide density. overwrite if you want to change the default
+   * value.
+   *
+   * @return min sulphur dioxide density
+   */
+  default double getMinSulphurDioxideDensity() {
+    return SulphurDioxideDensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for sulphur dioxide density. overwrite if you want to change the default
+   * value.
+   *
+   * @return max sulphur dioxide density
+   */
+  default double getMaxSulphurDioxideDensity() {
+    return SulphurDioxideDensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for sulphur dioxide density. overwrite if you want to change the
+   * default value.
+   *
+   * @return min step sulphur dioxide density
+   */
+  default double getMinStepSulphurDioxideDensity() {
+    return SulphurDioxideDensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in sulphur dioxide density.

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithVOCDensity.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithVOCDensity.java
@@ -1,6 +1,7 @@
 package io.github.hapjava.accessories.optionalcharacteristic;
 
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.characteristics.impl.airquality.VOCDensityCharacteristic;
 import java.util.concurrent.CompletableFuture;
 
 /** Accessory with VOC Density characteristic. */
@@ -12,6 +13,33 @@ public interface AccessoryWithVOCDensity {
    * @return a future with the VOC density
    */
   CompletableFuture<Double> getVOCDensity();
+
+  /**
+   * return the min value for VOC density. overwrite if you want to change the default value.
+   *
+   * @return min VOC density
+   */
+  default double getMinVOCDensity() {
+    return VOCDensityCharacteristic.DEFAULT_MIN_VALUE;
+  }
+
+  /**
+   * return the max value for VOC density. overwrite if you want to change the default value.
+   *
+   * @return max VOC density
+   */
+  default double getMaxVOCDensity() {
+    return VOCDensityCharacteristic.DEFAULT_MAX_VALUE;
+  }
+
+  /**
+   * return the min step value for VOC density. overwrite if you want to change the default value.
+   *
+   * @return min step VOC density
+   */
+  default double getMinStepVOCDensity() {
+    return VOCDensityCharacteristic.DEFAULT_STEP;
+  }
 
   /**
    * Subscribes to changes in VOC density.

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/NitrogenDioxideDensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/NitrogenDioxideDensityCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic contains the current NO2 density in micrograms/m3. */
 public class NitrogenDioxideDensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public NitrogenDioxideDensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C4-0000-1000-8000-0026BB765291",
         "nitrogen dioxide density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public NitrogenDioxideDensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/OzoneDensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/OzoneDensityCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic contains the current ozone density in micrograms/m3. */
 public class OzoneDensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public OzoneDensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C3-0000-1000-8000-0026BB765291",
         "ozone density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public OzoneDensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/PM10DensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/PM10DensityCharacteristic.java
@@ -11,21 +11,34 @@ import java.util.function.Supplier;
  * This characteristic contains the current PM10 micrometer particulate density in micrograms/m3.
  */
 public class PM10DensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public PM10DensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C7-0000-1000-8000-0026BB765291",
         "PM10 density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public PM10DensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/PM25DensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/PM25DensityCharacteristic.java
@@ -11,21 +11,34 @@ import java.util.function.Supplier;
  * This characteristic contains the current PM2.5 micrometer particulate density in micrograms/m3.
  */
 public class PM25DensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public PM25DensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C6-0000-1000-8000-0026BB765291",
         "PM2.5 density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public PM25DensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/SulphurDioxideDensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/SulphurDioxideDensityCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic contains the current SO2 density in micrograms/m3. */
 public class SulphurDioxideDensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public SulphurDioxideDensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C5-0000-1000-8000-0026BB765291",
         "sulphur dioxide density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public SulphurDioxideDensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/airquality/VOCDensityCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/airquality/VOCDensityCharacteristic.java
@@ -12,21 +12,34 @@ import java.util.function.Supplier;
  * micrograms/m3.
  */
 public class VOCDensityCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 1000;
+  public static final double DEFAULT_STEP = 1;
 
   public VOCDensityCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000C8-0000-1000-8000-0026BB765291",
         "VOC density",
-        0,
-        1000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "micrograms",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public VOCDensityCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/carbondioxidesensor/CarbonDioxideLevelCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/carbondioxidesensor/CarbonDioxideLevelCharacteristic.java
@@ -11,21 +11,34 @@ import java.util.function.Supplier;
  * This characteristic indicates the detected level of Carbon Dioxide in parts per million (ppm).
  */
 public class CarbonDioxideLevelCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 100000;
+  public static final double DEFAULT_STEP = 1;
 
   public CarbonDioxideLevelCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "00000093-0000-1000-8000-0026BB765291",
         "Carbon Dioxide Level",
-        0,
-        100000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "ppm",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public CarbonDioxideLevelCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/carbondioxidesensor/CarbonDioxidePeakLevelCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/carbondioxidesensor/CarbonDioxidePeakLevelCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic indicates the highest detected level (ppm) of carbon dioxide. */
 public class CarbonDioxidePeakLevelCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 100000;
+  public static final double DEFAULT_STEP = 1;
 
   public CarbonDioxidePeakLevelCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "00000094-0000-1000-8000-0026BB765291",
         "Carbon Dioxide Level",
-        0,
-        100000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "ppm",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public CarbonDioxidePeakLevelCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/carbonmonoxidesensor/CarbonMonoxideLevelCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/carbonmonoxidesensor/CarbonMonoxideLevelCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic contains the Carbon Monoxide levels in parts per million (ppm). */
 public class CarbonMonoxideLevelCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 100;
+  public static final double DEFAULT_STEP = 1;
 
   public CarbonMonoxideLevelCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "00000090-0000-1000-8000-0026BB765291",
         "Carbon Monoxide Level",
-        0,
-        100,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "ppm",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public CarbonMonoxideLevelCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/carbonmonoxidesensor/CarbonMonoxidePeakLevelCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/carbonmonoxidesensor/CarbonMonoxidePeakLevelCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic indicates the highest detected level (ppm) of Carbon Monoxide. */
 public class CarbonMonoxidePeakLevelCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 100;
+  public static final double DEFAULT_STEP = 1;
 
   public CarbonMonoxidePeakLevelCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "00000091-0000-1000-8000-0026BB765291",
         "Carbon Monoxide Peak Level",
-        0,
-        100000,
-        1,
+        minValue,
+        maxValue,
+        minStep,
         "ppm",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public CarbonMonoxidePeakLevelCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/lightbulb/ColorTemperatureCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/lightbulb/ColorTemperatureCharacteristic.java
@@ -12,8 +12,12 @@ import java.util.function.Supplier;
 /** This characteristic describes color temperature in Kelvin */
 public class ColorTemperatureCharacteristic extends IntegerCharacteristic
     implements EventableCharacteristic {
+  public static final int DEFAULT_MIN_VALUE = 50;
+  public static final int DEFAULT_MAX_VALUE = 400;
 
   public ColorTemperatureCharacteristic(
+      int minValue,
+      int maxValue,
       Supplier<CompletableFuture<Integer>> getter,
       ExceptionalConsumer<Integer> setter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
@@ -21,12 +25,20 @@ public class ColorTemperatureCharacteristic extends IntegerCharacteristic
     super(
         "000000CE-0000-1000-8000-0026BB765291",
         "color temperature",
-        50,
-        400,
+        minValue,
+        maxValue,
         "K",
         Optional.of(getter),
         Optional.of(setter),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public ColorTemperatureCharacteristic(
+      Supplier<CompletableFuture<Integer>> getter,
+      ExceptionalConsumer<Integer> setter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, getter, setter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/lightsensor/CurrentAmbientLightLevelCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/lightsensor/CurrentAmbientLightLevelCharacteristic.java
@@ -9,21 +9,34 @@ import java.util.function.Supplier;
 
 /** This characteristic indicates the current light level in Lux */
 public class CurrentAmbientLightLevelCharacteristic extends FloatCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0.0001;
+  public static final double DEFAULT_MAX_VALUE = 100000;
+  public static final double DEFAULT_STEP = 0.0001;
 
   public CurrentAmbientLightLevelCharacteristic(
+      double minValue,
+      double maxValue,
+      double minStep,
       Supplier<CompletableFuture<Double>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "0000006B-0000-1000-8000-0026BB765291",
         "ambient light level",
-        0.0001,
-        100000,
-        0.0001,
+        minValue,
+        maxValue,
+        minStep,
         "lux",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public CurrentAmbientLightLevelCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, DEFAULT_STEP, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/valve/RemainingDurationCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/valve/RemainingDurationCharacteristic.java
@@ -15,20 +15,31 @@ import java.util.function.Supplier;
  */
 public class RemainingDurationCharacteristic extends IntegerCharacteristic
     implements EventableCharacteristic {
+  public static final int DEFAULT_MIN_VALUE = 0;
+  public static final int DEFAULT_MAX_VALUE = 3600;
 
   public RemainingDurationCharacteristic(
+      int minValue,
+      int maxValue,
       Supplier<CompletableFuture<Integer>> getter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "000000D4-0000-1000-8000-0026BB765291",
         "remaining duration",
-        0,
-        3600,
+        minValue,
+        maxValue,
         "s",
         Optional.of(getter),
         Optional.empty(),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public RemainingDurationCharacteristic(
+      Supplier<CompletableFuture<Integer>> getter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, getter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/valve/SetDurationCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/valve/SetDurationCharacteristic.java
@@ -12,8 +12,12 @@ import java.util.function.Supplier;
 /** This characteristic describes the duration, how long an accessory should be set to "InUse". */
 public class SetDurationCharacteristic extends IntegerCharacteristic
     implements EventableCharacteristic {
+  public static final int DEFAULT_MIN_VALUE = 0;
+  public static final int DEFAULT_MAX_VALUE = 3600;
 
   public SetDurationCharacteristic(
+      int minValue,
+      int maxValue,
       Supplier<CompletableFuture<Integer>> getter,
       ExceptionalConsumer<Integer> setter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
@@ -21,12 +25,20 @@ public class SetDurationCharacteristic extends IntegerCharacteristic
     super(
         "000000D3-0000-1000-8000-0026BB765291",
         "set duration",
-        0,
-        3600,
+        minValue,
+        maxValue,
         "s",
         Optional.of(getter),
         Optional.of(setter),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public SetDurationCharacteristic(
+      Supplier<CompletableFuture<Integer>> getter,
+      ExceptionalConsumer<Integer> setter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, getter, setter, subscriber, unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/services/impl/AirQualityService.java
+++ b/src/main/java/io/github/hapjava/services/impl/AirQualityService.java
@@ -53,6 +53,9 @@ public class AirQualityService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithNitrogenDioxideDensity) {
       addOptionalCharacteristic(
           new NitrogenDioxideDensityCharacteristic(
+              ((AccessoryWithNitrogenDioxideDensity) accessory).getMinNitrogenDioxideDensity(),
+              ((AccessoryWithNitrogenDioxideDensity) accessory).getMaxNitrogenDioxideDensity(),
+              ((AccessoryWithNitrogenDioxideDensity) accessory).getMinStepNitrogenDioxideDensity(),
               ((AccessoryWithNitrogenDioxideDensity) accessory)::getNitrogenDioxideDensity,
               ((AccessoryWithNitrogenDioxideDensity) accessory)::subscribeNitrogenDioxideDensity,
               ((AccessoryWithNitrogenDioxideDensity) accessory)
@@ -62,6 +65,9 @@ public class AirQualityService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithSulphurDioxideDensity) {
       addOptionalCharacteristic(
           new SulphurDioxideDensityCharacteristic(
+              ((AccessoryWithSulphurDioxideDensity) accessory).getMinSulphurDioxideDensity(),
+              ((AccessoryWithSulphurDioxideDensity) accessory).getMaxSulphurDioxideDensity(),
+              ((AccessoryWithSulphurDioxideDensity) accessory).getMinStepSulphurDioxideDensity(),
               ((AccessoryWithSulphurDioxideDensity) accessory)::getSulphurDioxideDensity,
               ((AccessoryWithSulphurDioxideDensity) accessory)::subscribeSulphurDioxideDensity,
               ((AccessoryWithSulphurDioxideDensity) accessory)::unsubscribeSulphurDioxideDensity));
@@ -69,6 +75,9 @@ public class AirQualityService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithPM25Density) {
       addOptionalCharacteristic(
           new PM25DensityCharacteristic(
+              ((AccessoryWithPM25Density) accessory).getMinPM25Density(),
+              ((AccessoryWithPM25Density) accessory).getMaxPM25Density(),
+              ((AccessoryWithPM25Density) accessory).getMinStepPM25Density(),
               ((AccessoryWithPM25Density) accessory)::getPM25Density,
               ((AccessoryWithPM25Density) accessory)::subscribePM25Density,
               ((AccessoryWithPM25Density) accessory)::unsubscribePM25Density));
@@ -76,6 +85,9 @@ public class AirQualityService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithPM10Density) {
       addOptionalCharacteristic(
           new PM10DensityCharacteristic(
+              ((AccessoryWithPM10Density) accessory).getMinPM10Density(),
+              ((AccessoryWithPM10Density) accessory).getMaxPM10Density(),
+              ((AccessoryWithPM10Density) accessory).getMinStepPM10Density(),
               ((AccessoryWithPM10Density) accessory)::getPM10Density,
               ((AccessoryWithPM10Density) accessory)::subscribePM10Density,
               ((AccessoryWithPM10Density) accessory)::unsubscribePM10Density));
@@ -83,6 +95,9 @@ public class AirQualityService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithVOCDensity) {
       addOptionalCharacteristic(
           new VOCDensityCharacteristic(
+              ((AccessoryWithVOCDensity) accessory).getMinVOCDensity(),
+              ((AccessoryWithVOCDensity) accessory).getMaxVOCDensity(),
+              ((AccessoryWithVOCDensity) accessory).getMinStepVOCDensity(),
               ((AccessoryWithVOCDensity) accessory)::getVOCDensity,
               ((AccessoryWithVOCDensity) accessory)::subscribeVOCDensity,
               ((AccessoryWithVOCDensity) accessory)::unsubscribeVOCDensity));

--- a/src/main/java/io/github/hapjava/services/impl/CarbonDioxideSensorService.java
+++ b/src/main/java/io/github/hapjava/services/impl/CarbonDioxideSensorService.java
@@ -34,11 +34,17 @@ public class CarbonDioxideSensorService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithCarbonDioxideLevel) {
       addOptionalCharacteristic(
           new CarbonDioxideLevelCharacteristic(
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMinCarbonDioxideLevel(),
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMaxCarbonDioxideLevel(),
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMinStepCarbonDioxideLevel(),
               ((AccessoryWithCarbonDioxideLevel) accessory)::getCarbonDioxideLevel,
               ((AccessoryWithCarbonDioxideLevel) accessory)::subscribeCarbonDioxideLevel,
               ((AccessoryWithCarbonDioxideLevel) accessory)::unsubscribeCarbonDioxideLevel));
       addOptionalCharacteristic(
           new CarbonDioxidePeakLevelCharacteristic(
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMinCarbonDioxidePeakLevel(),
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMaxCarbonDioxidePeakLevel(),
+              ((AccessoryWithCarbonDioxideLevel) accessory).getMinStepCarbonDioxidePeakLevel(),
               ((AccessoryWithCarbonDioxideLevel) accessory)::getCarbonDioxidePeakLevel,
               ((AccessoryWithCarbonDioxideLevel) accessory)::subscribeCarbonDioxidePeakLevel,
               ((AccessoryWithCarbonDioxideLevel) accessory)::unsubscribeCarbonDioxidePeakLevel));

--- a/src/main/java/io/github/hapjava/services/impl/LightSensorService.java
+++ b/src/main/java/io/github/hapjava/services/impl/LightSensorService.java
@@ -24,6 +24,9 @@ public class LightSensorService extends AbstractServiceImpl {
   public LightSensorService(LightSensorAccessory accessory) {
     this(
         new CurrentAmbientLightLevelCharacteristic(
+            accessory.getMinCurrentAmbientLightLevel(),
+            accessory.getMaxCurrentAmbientLightLevel(),
+            accessory.getMinStepCurrentAmbientLightLevel(),
             accessory::getCurrentAmbientLightLevel,
             accessory::subscribeCurrentAmbientLightLevel,
             accessory::unsubscribeCurrentAmbientLightLevel));

--- a/src/main/java/io/github/hapjava/services/impl/LightbulbService.java
+++ b/src/main/java/io/github/hapjava/services/impl/LightbulbService.java
@@ -55,6 +55,8 @@ public class LightbulbService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithColorTemperature) {
       addOptionalCharacteristic(
           new ColorTemperatureCharacteristic(
+              ((AccessoryWithColorTemperature) accessory).getMinColorTemperature(),
+              ((AccessoryWithColorTemperature) accessory).getMaxColorTemperature(),
               ((AccessoryWithColorTemperature) accessory)::getColorTemperature,
               ((AccessoryWithColorTemperature) accessory)::setColorTemperature,
               ((AccessoryWithColorTemperature) accessory)::subscribeColorTemperature,

--- a/src/main/java/io/github/hapjava/services/impl/ThermostatService.java
+++ b/src/main/java/io/github/hapjava/services/impl/ThermostatService.java
@@ -74,6 +74,12 @@ public class ThermostatService extends AbstractServiceImpl {
       addOptionalCharacteristic(
           new CoolingThresholdTemperatureCharacteristic(
               ((AccessoryWithCoolingThresholdTemperature) accessory)
+                  .getMinCoolingThresholdTemperature(),
+              ((AccessoryWithCoolingThresholdTemperature) accessory)
+                  .getMaxCoolingThresholdTemperature(),
+              ((AccessoryWithCoolingThresholdTemperature) accessory)
+                  .getStepCoolingThresholdTemperature(),
+              ((AccessoryWithCoolingThresholdTemperature) accessory)
                   ::getCoolingThresholdTemperature,
               ((AccessoryWithCoolingThresholdTemperature) accessory)
                   ::setCoolingThresholdTemperature,
@@ -85,6 +91,12 @@ public class ThermostatService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithHeatingThresholdTemperature) {
       addOptionalCharacteristic(
           new HeatingThresholdTemperatureCharacteristic(
+              ((AccessoryWithHeatingThresholdTemperature) accessory)
+                  .getMinHeatingThresholdTemperature(),
+              ((AccessoryWithHeatingThresholdTemperature) accessory)
+                  .getMaxHeatingThresholdTemperature(),
+              ((AccessoryWithHeatingThresholdTemperature) accessory)
+                  .getStepHeatingThresholdTemperature(),
               ((AccessoryWithHeatingThresholdTemperature) accessory)
                   ::getHeatingThresholdTemperature,
               ((AccessoryWithHeatingThresholdTemperature) accessory)

--- a/src/main/java/io/github/hapjava/services/impl/ValveService.java
+++ b/src/main/java/io/github/hapjava/services/impl/ValveService.java
@@ -58,6 +58,8 @@ public class ValveService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithDuration) {
       addOptionalCharacteristic(
           new SetDurationCharacteristic(
+              ((AccessoryWithDuration) accessory).getMinDuration(),
+              ((AccessoryWithDuration) accessory).getMaxDuration(),
               ((AccessoryWithDuration) accessory)::getSetDuration,
               ((AccessoryWithDuration) accessory)::setSetDuration,
               ((AccessoryWithDuration) accessory)::subscribeSetDuration,
@@ -66,6 +68,8 @@ public class ValveService extends AbstractServiceImpl {
     if (accessory instanceof AccessoryWithRemainingDuration) {
       addOptionalCharacteristic(
           new RemainingDurationCharacteristic(
+              ((AccessoryWithRemainingDuration) accessory).getMinRemainingDuration(),
+              ((AccessoryWithRemainingDuration) accessory).getMaxRemainingDuration(),
               ((AccessoryWithRemainingDuration) accessory)::getRemainingDuration,
               ((AccessoryWithRemainingDuration) accessory)::subscribeRemainingDuration,
               ((AccessoryWithRemainingDuration) accessory)::unsubscribeRemainingDuration));


### PR DESCRIPTION
extend support for custom min/max/step value to further characteristics:

- Carbon Dioxide Level 
- Carbon Dioxide Peak Level 
- Carbon Monoxide Level 
- Carbon Monoxide Peak Level 
- Duration (Valve)
- Remaining Duration (Valve)
- Ambient Light Level 
- PM10 Density
- PM25 Density
- Ozone Density
- Nitrogen Dioxide Density
- Sulphur Dioxide Density
- VOC Density

it is done in the same way as for already existing characteristics with min/max/step support, e.g. temperatures

Signed-off-by: Eugen Freiter <freiter@gmx.de>


