### PR TITLE
Fix site-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,10 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
         server-username: MAVEN_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN
+    - name: Setup git profile
+      run: |
+        git config --global user.name github-actions
+        git config --global user.email github-actions@github.com
     - name: Publish to Maven Central
       run: mvn deploy
       env:
@@ -31,4 +35,4 @@ jobs:
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     - name: Publish site
-      run: mvn deploy-site
+      run: mvn -B site-deploy -Dusername=github-actions -Dpassword=${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Include HAP-Java in your project using maven:
 </dependency>
 ```
 
-After that, check out the [Sample](https://github.com/hap-java/HAP-Java/tree/sample).
+After that, check out the [Sample](https://github.com/hap-java/HAP-Java/tree/sample) and
+read the [Javadoc](https://hap-java.github.io/HAP-Java/apidocs/index.html)
 
 Supported HomeKit Accessories
 =========

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-scm-publish-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>scm-publish</id>


### PR DESCRIPTION
Turns out wagon-scm doesn’t pick up the github properties the way the release plugin does. This fixes the site deploy.

Fixes #141 

# Pull Request Checklist

Please confirm that you've done the following when opening a new pull request:

  - [x] For fixes and other improvements, please reference the GitHub issue that your change addresses.
  - [n/a] For fixes, optimizations and new features, please add an entry to the CHANGES.md file.
  - [x] Run mvn compile before committing, so that the auto-code formatter will format your changes consistently with the rest of the project.

