### PR TITLE
upgrade netty to 4.1.72.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<netty.version>4.1.42.Final</netty.version>
+		<netty.version>4.1.72.Final</netty.version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
i think it is time to upgrade netty. there are many important fixes including log4j security fix.
the version is also align with OH netty version. 

Signed-off-by: Eugen Freiter <freiter@gmx.de>


