### PR TITLE
Fix rotation speed type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # HAP-Java 2.0.1
 ## Fixes
 * Log accessory names instead of futures. [#150](https://github.com/hap-java/HAP-Java/issues/150)
+* Fix rotation speed data type (BREAKING API CHANGE). According to HAP specification it must be float
 
 # HAP-Java 2.0.0
 * major refactoring to support optional characteristics

--- a/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithRotationSpeed.java
+++ b/src/main/java/io/github/hapjava/accessories/optionalcharacteristic/AccessoryWithRotationSpeed.java
@@ -11,7 +11,7 @@ public interface AccessoryWithRotationSpeed {
    *
    * @return a future that will contain the speed, expressed as an integer between 0 and 100.
    */
-  CompletableFuture<Integer> getRotationSpeed();
+  CompletableFuture<Double> getRotationSpeed();
 
   /**
    * Sets the speed of the rotation
@@ -20,7 +20,7 @@ public interface AccessoryWithRotationSpeed {
    * @return a future that completes when the change is made
    * @throws Exception when the change cannot be made
    */
-  CompletableFuture<Void> setRotationSpeed(Integer speed) throws Exception;
+  CompletableFuture<Void> setRotationSpeed(Double speed) throws Exception;
 
   /**
    * Subscribes to changes in the rotation speed.

--- a/src/main/java/io/github/hapjava/characteristics/impl/fan/RotationSpeedCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/fan/RotationSpeedCharacteristic.java
@@ -3,30 +3,52 @@ package io.github.hapjava.characteristics.impl.fan;
 import io.github.hapjava.characteristics.EventableCharacteristic;
 import io.github.hapjava.characteristics.ExceptionalConsumer;
 import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
-import io.github.hapjava.characteristics.impl.base.IntegerCharacteristic;
+import io.github.hapjava.characteristics.impl.base.FloatCharacteristic;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /** This characteristic describes the rotation speed of a fan. */
-public class RotationSpeedCharacteristic extends IntegerCharacteristic
+public class RotationSpeedCharacteristic extends FloatCharacteristic
     implements EventableCharacteristic {
+  public static final double DEFAULT_MIN_VALUE = 0;
+  public static final double DEFAULT_MAX_VALUE = 100;
+  public static final double DEFAULT_STEP = 25;
 
   public RotationSpeedCharacteristic(
-      Supplier<CompletableFuture<Integer>> getter,
-      ExceptionalConsumer<Integer> setter,
+      double minValue,
+      double maxValue,
+      double minStep,
+      Supplier<CompletableFuture<Double>> getter,
+      ExceptionalConsumer<Double> setter,
       Consumer<HomekitCharacteristicChangeCallback> subscriber,
       Runnable unsubscriber) {
     super(
         "00000029-0000-1000-8000-0026BB765291",
         "Rotation Speed",
-        0,
-        100,
+        minValue,
+        maxValue,
+        minStep,
         "%",
         Optional.of(getter),
         Optional.of(setter),
         Optional.of(subscriber),
         Optional.of(unsubscriber));
+  }
+
+  public RotationSpeedCharacteristic(
+      Supplier<CompletableFuture<Double>> getter,
+      ExceptionalConsumer<Double> setter,
+      Consumer<HomekitCharacteristicChangeCallback> subscriber,
+      Runnable unsubscriber) {
+    this(
+        DEFAULT_MIN_VALUE,
+        DEFAULT_MAX_VALUE,
+        DEFAULT_STEP,
+        getter,
+        setter,
+        subscriber,
+        unsubscriber);
   }
 }

--- a/src/main/java/io/github/hapjava/characteristics/impl/fan/RotationSpeedCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/fan/RotationSpeedCharacteristic.java
@@ -14,7 +14,7 @@ public class RotationSpeedCharacteristic extends FloatCharacteristic
     implements EventableCharacteristic {
   public static final double DEFAULT_MIN_VALUE = 0;
   public static final double DEFAULT_MAX_VALUE = 100;
-  public static final double DEFAULT_STEP = 25;
+  public static final double DEFAULT_STEP = 1;
 
   public RotationSpeedCharacteristic(
       double minValue,


### PR DESCRIPTION
Rotation speed characteristic must be of type float according to apple HAP specification. 
we had it as integration. 

this PR change the data type to float. It change the interface so that implementation would need to adapt as well. 

it also makes min/max/step configurable.