### PR TITLE
add support for HomeKit categories

### DIFF
--- a/src/main/java/io/github/hapjava/server/HomekitAccessoryCategories.java
+++ b/src/main/java/io/github/hapjava/server/HomekitAccessoryCategories.java
@@ -1,0 +1,40 @@
+package io.github.hapjava.server;
+
+public final class HomekitAccessoryCategories {
+  public static final int OTHER = 1;
+  public static final int BRIDGES = 2;
+  public static final int FANS = 3;
+  public static final int GARAGE_DOOR_OPENERS = 4;
+  public static final int LIGHTING = 5;
+  public static final int LOCKS = 6;
+  public static final int OUTLETS = 7;
+  public static final int SWITCHES = 8;
+  public static final int THERMOSTATS = 9;
+  public static final int SENSORS = 10;
+  public static final int SECURITY_SYSTEMS = 11;
+  public static final int DOORS = 12;
+  public static final int WINDOWS = 13;
+  public static final int WINDOW_COVERINGS = 14;
+  public static final int PROGRAMMABLE_SWITCHES = 15;
+  public static final int RANGE_EXTENDER = 16;
+  public static final int IP_CAMERAS = 17;
+  public static final int VIDEO_DOORBELLS = 18;
+  public static final int AIR_PURIFIERS = 19;
+  public static final int HEATERS = 20;
+  public static final int AIR_CONDITIONERS = 21;
+  public static final int HUMIDIFIERS = 22;
+  public static final int DEHUMIDIFIERS = 23;
+  public static final int APPLE_TV = 24;
+  public static final int HOMEPOD = 25;
+  public static final int SPEAKER = 26;
+  public static final int AIRPORT = 27;
+  public static final int SPRINKLERS = 28;
+  public static final int FAUCETS = 29;
+  public static final int SHOWER_SYSTEMS = 30;
+  public static final int TELEVISION = 31;
+  public static final int REMOTES = 32;
+  public static final int ROUTER = 33;
+  public static final int AUDIO_RECEIVER = 34;
+  public static final int TV_SET_TOP_BOX = 35;
+  public static final int TV_STREAMING_STICK = 36;
+}

--- a/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
@@ -139,6 +139,7 @@ public class HomekitServer {
   public HomekitRoot createBridge(
       HomekitAuthInfo authInfo,
       String label,
+      int category,
       String manufacturer,
       String model,
       String serialNumber,
@@ -147,9 +148,9 @@ public class HomekitServer {
       throws IOException {
     HomekitRoot root;
     if (jmdns != null) {
-      root = new HomekitRoot(label, http, jmdns, authInfo);
+      root = new HomekitRoot(label, category, http, jmdns, authInfo);
     } else {
-      root = new HomekitRoot(label, http, localAddress, authInfo);
+      root = new HomekitRoot(label, category, http, localAddress, authInfo);
     }
     root.addAccessory(
         new HomekitBridge(

--- a/src/main/java/io/github/hapjava/server/impl/http/impl/AccessoryHandler.java
+++ b/src/main/java/io/github/hapjava/server/impl/http/impl/AccessoryHandler.java
@@ -72,9 +72,9 @@ class AccessoryHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
             HttpVersion.HTTP_1_1,
             status,
             Unpooled.copiedBuffer(responseBody.getBytes(StandardCharsets.UTF_8)));
-    response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
-    response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
-    response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+    response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
+    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+    response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
     ctx.write(response);
     ctx.flush();
   }

--- a/src/main/java/io/github/hapjava/server/impl/http/impl/DefaultHttpRequestImpl.java
+++ b/src/main/java/io/github/hapjava/server/impl/http/impl/DefaultHttpRequestImpl.java
@@ -13,7 +13,7 @@ class DefaultHttpRequestImpl implements HttpRequest {
 
   @Override
   public String getUri() {
-    return request.getUri();
+    return request.uri();
   }
 
   @Override
@@ -23,7 +23,7 @@ class DefaultHttpRequestImpl implements HttpRequest {
 
   @Override
   public HttpMethod getMethod() {
-    io.netty.handler.codec.http.HttpMethod method = request.getMethod();
+    io.netty.handler.codec.http.HttpMethod method = request.method();
     if (method.equals(io.netty.handler.codec.http.HttpMethod.GET)) {
       return HttpMethod.GET;
     } else if (method.equals(io.netty.handler.codec.http.HttpMethod.POST)) {

--- a/src/main/java/io/github/hapjava/server/impl/http/impl/NettyResponseUtil.java
+++ b/src/main/java/io/github/hapjava/server/impl/http/impl/NettyResponseUtil.java
@@ -4,7 +4,8 @@ import io.github.hapjava.server.impl.http.HttpResponse;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.util.Map.Entry;
@@ -25,8 +26,8 @@ class NettyResponseUtil {
     for (Entry<String, String> header : homekitResponse.getHeaders().entrySet()) {
       response.headers().add(header.getKey(), header.getValue());
     }
-    response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
-    response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+    response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
     return response;
   }
 }

--- a/src/main/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiser.java
+++ b/src/main/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiser.java
@@ -27,6 +27,7 @@ public class JmdnsHomekitAdvertiser {
   private int port;
   private int configurationIndex;
   private ServiceInfo serviceInfo;
+  private int category;
 
   public JmdnsHomekitAdvertiser(JmDNS jmdns) {
     this.jmdns = jmdns;
@@ -37,7 +38,8 @@ public class JmdnsHomekitAdvertiser {
   }
 
   public synchronized void advertise(
-      String label, String mac, int port, int configurationIndex, String setupId) throws Exception {
+      String label, int category, String mac, int port, int configurationIndex, String setupId)
+      throws Exception {
     if (isAdvertising) {
       throw new IllegalStateException("HomeKit advertiser is already running");
     }
@@ -45,6 +47,7 @@ public class JmdnsHomekitAdvertiser {
     this.mac = mac;
     this.port = port;
     this.setupId = setupId;
+    this.category = category;
     this.configurationIndex = configurationIndex;
 
     logger.trace("Advertising accessory " + label);
@@ -114,7 +117,9 @@ public class JmdnsHomekitAdvertiser {
     props.put("c#", Integer.toString(configurationIndex));
     props.put("s#", "1");
     props.put("ff", "0");
-    props.put("ci", "1");
+    props.put("ci", Integer.toString(category));
+    props.put("pv", "1.1");
+
     return ServiceInfo.create(SERVICE_TYPE, label, port, 1, 1, props);
   }
 }

--- a/src/test/java/io/github/hapjava/server/impl/HomekitRootTest.java
+++ b/src/test/java/io/github/hapjava/server/impl/HomekitRootTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.hapjava.accessories.HomekitAccessory;
+import io.github.hapjava.server.HomekitAccessoryCategories;
 import io.github.hapjava.server.HomekitAuthInfo;
 import io.github.hapjava.server.HomekitWebHandler;
 import io.github.hapjava.server.impl.http.HomekitClientConnectionFactory;
@@ -38,7 +39,8 @@ public class HomekitRootTest {
     when(webHandler.start(any())).thenReturn(CompletableFuture.completedFuture(PORT));
     advertiser = mock(JmdnsHomekitAdvertiser.class);
     authInfo = mock(HomekitAuthInfo.class);
-    root = new HomekitRoot(LABEL, webHandler, authInfo, advertiser);
+    root =
+        new HomekitRoot(LABEL, HomekitAccessoryCategories.OTHER, webHandler, authInfo, advertiser);
   }
 
   @Test
@@ -78,7 +80,7 @@ public class HomekitRootTest {
     when(authInfo.getSetupId()).thenReturn(SETUPID);
 
     root.start();
-    verify(advertiser).advertise(eq(LABEL), eq(mac), eq(PORT), eq(1), eq(SETUPID));
+    verify(advertiser).advertise(eq(LABEL), eq(1), eq(mac), eq(PORT), eq(1), eq(SETUPID));
   }
 
   @Test

--- a/src/test/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiserTest.java
+++ b/src/test/java/io/github/hapjava/server/impl/jmdns/JmdnsHomekitAdvertiserTest.java
@@ -61,6 +61,6 @@ public class JmdnsHomekitAdvertiserTest {
   }
 
   private void advertise() throws Exception {
-    subject.advertise("test", "00:00:00:00:00:00", 1234, 1, "1");
+    subject.advertise("test", 1, "00:00:00:00:00:00", 1234, 1, "1");
   }
 }


### PR DESCRIPTION
- add support for HomeKit categories, so that bridge can pretend different accessory like Television
- add protocol version to mDNS parameters "pv":"1.1.". this is required according to HAP spec, but could not detect any difference until now. probably home app is not checking it
- replace netty deprecated methods. it looks like netty just did renaming of classes without changing the logic. 

i would make release after this PR if there are no objections. 

Signed-off-by: Eugen Freiter <freiter@gmx.de>
