### PR TITLE
mark primary service

### DIFF
--- a/src/main/java/io/github/hapjava/accessories/HomekitAccessory.java
+++ b/src/main/java/io/github/hapjava/accessories/HomekitAccessory.java
@@ -86,6 +86,6 @@ public interface HomekitAccessory {
    * @return primary service
    */
   default Service getPrimaryService() {
-    return getServices().iterator().next();
+    return getServices().isEmpty() ? null : getServices().iterator().next();
   };
 }

--- a/src/main/java/io/github/hapjava/server/impl/json/AccessoryController.java
+++ b/src/main/java/io/github/hapjava/server/impl/json/AccessoryController.java
@@ -42,7 +42,7 @@ public class AccessoryController {
       iidLookup.putAll(swapKeyAndValue(registry.getCharacteristics(accessory.getId())));
 
       for (Service service : servicesByInterfaceId.values()) {
-        serviceFutures.add(toJson(service, iidLookup));
+        serviceFutures.add(toJson(service, iidLookup, accessory.getPrimaryService() == service));
       }
 
       accessoryServiceFutures.put(accessory.getId(), serviceFutures);
@@ -72,8 +72,8 @@ public class AccessoryController {
     }
   }
 
-  private CompletableFuture<JsonObject> toJson(Service service, Map<Object, Integer> iidLookup)
-      throws Exception {
+  private CompletableFuture<JsonObject> toJson(
+      Service service, Map<Object, Integer> iidLookup, boolean isPrimary) throws Exception {
     String shortType =
         service.getType().replaceAll("^0*([0-9a-fA-F]+)-0000-1000-8000-0026BB765291$", "$1");
     JsonObjectBuilder builder =
@@ -103,7 +103,7 @@ public class AccessoryController {
                     .forEach(jsonLinkedServices::add);
                 builder.add("linked", jsonLinkedServices);
               }
-
+              builder.add("primary", isPrimary);
               return builder.build();
             });
   }


### PR DESCRIPTION
according to HAP spec one service should be marked as primary. this is especially important for accessories with multiple services.

```
2.3.2.3 Primary Service
Accessories should list one of its services as the primary service. The primary service must match the primary function of the accessory and must also match with the accessory category. An accessory must expose only one primary service from its list of available services.
```


Signed-off-by: Eugen Freiter <freiter@gmx.de>

