### PR TITLE
add back fanv1 service

### DIFF
--- a/src/main/java/io/github/hapjava/accessories/BasicFanAccessory.java
+++ b/src/main/java/io/github/hapjava/accessories/BasicFanAccessory.java
@@ -1,0 +1,46 @@
+package io.github.hapjava.accessories;
+
+import io.github.hapjava.characteristics.HomekitCharacteristicChangeCallback;
+import io.github.hapjava.services.Service;
+import io.github.hapjava.services.impl.BasicFanService;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A fan with mandatory characteristics.
+ *
+ * @author Andy Lintner
+ */
+public interface BasicFanAccessory extends HomekitAccessory {
+  /**
+   * Mandatory: Retrieves the current power state of the fan.
+   *
+   * @return a future that will contain the binary state
+   */
+  CompletableFuture<Boolean> isOn();
+
+  /**
+   * Sets the active state of the fan
+   *
+   * @param state the binary state to set
+   * @return a future that completes when the change is made
+   * @throws Exception when the change cannot be made
+   */
+  CompletableFuture<Void> setOn(boolean state) throws Exception;
+
+  /**
+   * Subscribes to changes in the active state of the fan.
+   *
+   * @param callback the function to call when the active state changes.
+   */
+  void subscribeOn(HomekitCharacteristicChangeCallback callback);
+
+  /** Unsubscribes from changes in the active state of the fan. */
+  void unsubscribeOn();
+
+  @Override
+  default Collection<Service> getServices() {
+    return Collections.singleton(new BasicFanService(this));
+  }
+}

--- a/src/main/java/io/github/hapjava/services/impl/BasicFanService.java
+++ b/src/main/java/io/github/hapjava/services/impl/BasicFanService.java
@@ -1,0 +1,65 @@
+package io.github.hapjava.services.impl;
+
+import io.github.hapjava.accessories.BasicFanAccessory;
+import io.github.hapjava.accessories.optionalcharacteristic.AccessoryWithName;
+import io.github.hapjava.accessories.optionalcharacteristic.AccessoryWithRotationDirection;
+import io.github.hapjava.accessories.optionalcharacteristic.AccessoryWithRotationSpeed;
+import io.github.hapjava.characteristics.impl.common.NameCharacteristic;
+import io.github.hapjava.characteristics.impl.common.OnCharacteristic;
+import io.github.hapjava.characteristics.impl.fan.RotationDirectionCharacteristic;
+import io.github.hapjava.characteristics.impl.fan.RotationSpeedCharacteristic;
+
+/**
+ * This service describes a fan.
+ *
+ * <p>In the R1 release of the HAP specification, this is simply described as Fan. It is no longer
+ * present in the R2 release.
+ */
+public class BasicFanService extends AbstractServiceImpl {
+
+  public BasicFanService(OnCharacteristic on) {
+    super("00000040-0000-1000-8000-0026BB765291");
+    addCharacteristic(on);
+  }
+
+  public BasicFanService(BasicFanAccessory accessory) {
+    this(
+        new OnCharacteristic(
+            () -> accessory.isOn(),
+            (v) -> accessory.setOn(v),
+            accessory::subscribeOn,
+            accessory::unsubscribeOn));
+    if (accessory instanceof AccessoryWithName) {
+      addOptionalCharacteristic(new NameCharacteristic(((AccessoryWithName) accessory)::getName));
+    }
+
+    if (accessory instanceof AccessoryWithRotationDirection) {
+      addOptionalCharacteristic(
+          new RotationDirectionCharacteristic(
+              ((AccessoryWithRotationDirection) accessory)::getRotationDirection,
+              ((AccessoryWithRotationDirection) accessory)::setRotationDirection,
+              ((AccessoryWithRotationDirection) accessory)::subscribeRotationDirection,
+              ((AccessoryWithRotationDirection) accessory)::unsubscribeRotationDirection));
+    }
+    if (accessory instanceof AccessoryWithRotationSpeed) {
+      addOptionalCharacteristic(
+          new RotationSpeedCharacteristic(
+              ((AccessoryWithRotationSpeed) accessory)::getRotationSpeed,
+              ((AccessoryWithRotationSpeed) accessory)::setRotationSpeed,
+              ((AccessoryWithRotationSpeed) accessory)::subscribeRotationSpeed,
+              ((AccessoryWithRotationSpeed) accessory)::unsubscribeRotationSpeed));
+    }
+  }
+
+  public void addOptionalCharacteristic(NameCharacteristic name) {
+    addCharacteristic(name);
+  }
+
+  public void addOptionalCharacteristic(RotationDirectionCharacteristic direction) {
+    addCharacteristic(direction);
+  }
+
+  public void addOptionalCharacteristic(RotationSpeedCharacteristic speed) {
+    addCharacteristic(speed);
+  }
+}

--- a/src/main/java/io/github/hapjava/services/impl/FanService.java
+++ b/src/main/java/io/github/hapjava/services/impl/FanService.java
@@ -17,7 +17,12 @@ import io.github.hapjava.characteristics.impl.fan.RotationSpeedCharacteristic;
 import io.github.hapjava.characteristics.impl.fan.SwingModeCharacteristic;
 import io.github.hapjava.characteristics.impl.fan.TargetFanStateCharacteristic;
 
-/** This service describes a fan. */
+/**
+ * This service describes a fan.
+ *
+ * <p>In the R1 release of the HAP specification, this is described as Fan v2. In the R1 release of
+ * the HAP specification, this is simply described as Fan.
+ */
 public class FanService extends AbstractServiceImpl {
 
   public FanService(ActiveCharacteristic active) {


### PR DESCRIPTION
the Home app doesn't let you customize the icon for a FanV2 (i.e. to show a ceiling fan).


I'm not sure if I'm ready to merge this yet. I've got it plumbed through to OpenHAB as well https://github.com/ccutrer/openhab-addons/commit/114fe0625d226098504a89243e763049abc53c42. When I tested, the accessory works as expected, EXCEPT that on iOS 16, the new Home refuses to show the fan anywhere except for if you go to the hub and list its accessories. Or if it's on it _does_ show on the top status line of a room. This feels like an iOS bug to me. So I'm going to let this hang out here until the next iOS update comes, and test again.

