### PR TITLE
exclude characteristic description for well-known types

### DIFF
--- a/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
@@ -112,8 +112,8 @@ public abstract class BaseCharacteristic<T> implements Characteristic, Eventable
                       .add("iid", instanceId)
                       .add("type", shortType)
                       .add("perms", perms.build())
-                      .add("format", format)
-                      .add("description", description);
+                      .add("format", format);
+              if (shortType.length() == type.length()) builder.add("description", description);
               if (isReadable) setJsonValue(builder, value);
               return builder;
             });


### PR DESCRIPTION
they're optional, and they just take up extra data


