### PR TITLE
keep subscriptions up to date when accessories are replaced

### DIFF
--- a/src/main/java/io/github/hapjava/characteristics/Characteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/Characteristic.java
@@ -18,6 +18,8 @@ import javax.json.JsonValue;
  * @author Andy Lintner
  */
 public interface Characteristic {
+  /** @return The UUID type for this characteristic. */
+  String getType();
 
   /**
    * Adds an attribute to the passed JsonObjectBuilder named "value" with the current value of the

--- a/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/base/BaseCharacteristic.java
@@ -72,6 +72,12 @@ public abstract class BaseCharacteristic<T> implements Characteristic, Eventable
 
   @Override
   /** {@inheritDoc} */
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  /** {@inheritDoc} */
   public final CompletableFuture<JsonObject> toJson(int iid) {
     return makeBuilder(iid).thenApply(builder -> builder.build());
   }

--- a/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
@@ -2,6 +2,7 @@ package io.github.hapjava.server.impl;
 
 import io.github.hapjava.accessories.HomekitAccessory;
 import io.github.hapjava.characteristics.Characteristic;
+import io.github.hapjava.server.impl.connections.SubscriptionManager;
 import io.github.hapjava.services.Service;
 import io.github.hapjava.services.impl.AccessoryInformationService;
 import java.util.ArrayList;
@@ -19,14 +20,16 @@ public class HomekitRegistry {
   private static final Logger logger = LoggerFactory.getLogger(HomekitRegistry.class);
 
   private final String label;
+  private final SubscriptionManager subscriptions;
   private final Map<Integer, HomekitAccessory> accessories;
   private final Map<HomekitAccessory, Map<Integer, Service>> services = new HashMap<>();
   private final Map<HomekitAccessory, Map<Integer, Characteristic>> characteristics =
       new HashMap<>();
   private boolean isAllowUnauthenticatedRequests = false;
 
-  public HomekitRegistry(String label) {
+  public HomekitRegistry(String label, SubscriptionManager subscriptions) {
     this.label = label;
+    this.subscriptions = subscriptions;
     this.accessories = new ConcurrentHashMap<>();
     reset();
   }
@@ -61,6 +64,7 @@ public class HomekitRegistry {
       services.put(accessory, newServicesByInterfaceId);
       characteristics.put(accessory, newCharacteristicsByInterfaceId);
     }
+    subscriptions.resync(this);
   }
 
   public String getLabel() {
@@ -87,8 +91,8 @@ public class HomekitRegistry {
     accessories.put(accessory.getId(), accessory);
   }
 
-  public void remove(HomekitAccessory accessory) {
-    accessories.remove(accessory.getId());
+  public boolean remove(HomekitAccessory accessory) {
+    return accessories.remove(accessory.getId()) != null;
   }
 
   public boolean isAllowUnauthenticatedRequests() {

--- a/src/main/java/io/github/hapjava/server/impl/HomekitRoot.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitRoot.java
@@ -86,11 +86,19 @@ public class HomekitRoot {
         label, DEFAULT_ACCESSORY_CATEGORY, webHandler, authInfo, new JmdnsHomekitAdvertiser(jmdns));
   }
 
+  /**
+   * Begin a batch update of accessories.
+   *
+   * <p>After calling this, you can call addAccessory() and removeAccessory() multiple times without
+   * causing HAP-Java to re-publishing the metadata to HomeKit. You'll need to call
+   * completeUpdateBatch in order to publish all accumulated changes.
+   */
   public synchronized void batchUpdate() {
     if (this.nestedBatches == 0) madeChanges = false;
     ++this.nestedBatches;
   }
 
+  /** Publish accumulated accessory changes since batchUpdate() was called. */
   public synchronized void completeUpdateBatch() {
     if (--this.nestedBatches == 0 && madeChanges) registry.reset();
   }

--- a/src/main/java/io/github/hapjava/server/impl/connections/SubscriptionManager.java
+++ b/src/main/java/io/github/hapjava/server/impl/connections/SubscriptionManager.java
@@ -58,7 +58,7 @@ public class SubscriptionManager {
         reverse.put(connection, new HashSet<>());
       }
       reverse.get(connection).add(characteristic);
-      LOGGER.debug(
+      LOGGER.trace(
           "Added subscription to {}:{} ({}) for {}",
           aid,
           iid,
@@ -73,7 +73,7 @@ public class SubscriptionManager {
     if (subscribers != null) {
       subscribers.connections.remove(connection);
       if (subscribers.connections.isEmpty()) {
-        LOGGER.debug("Unsubscribing from characteristic as all subscriptions are closed");
+        LOGGER.trace("Unsubscribing from characteristic as all subscriptions are closed");
         characteristic.unsubscribe();
         subscriptions.remove(characteristic);
       }
@@ -85,7 +85,7 @@ public class SubscriptionManager {
         if (connectionNotifications.isEmpty()) pendingNotifications.remove(connection);
       }
 
-      LOGGER.debug(
+      LOGGER.trace(
           "Removed subscription from {}:{} ({}) for {}",
           subscribers.aid,
           subscribers.iid,
@@ -112,7 +112,7 @@ public class SubscriptionManager {
         removeSubscription(characteristic, connection);
       }
     }
-    LOGGER.debug("Removed connection {}", connection.hashCode());
+    LOGGER.trace("Removed connection {}", connection.hashCode());
   }
 
   public synchronized void batchUpdate() {
@@ -173,7 +173,7 @@ public class SubscriptionManager {
    * characteristics
    */
   public synchronized void resync(HomekitRegistry registry) {
-    LOGGER.debug("Resyncing subscriptions");
+    LOGGER.trace("Resyncing subscriptions");
     flushUpdateBatch();
 
     Map<EventableCharacteristic, ConnectionsWithIds> newSubscriptions = new HashMap<>();
@@ -187,7 +187,7 @@ public class SubscriptionManager {
           registry.getCharacteristics(subscribers.aid).get(subscribers.iid);
       if (newCharacteristic == null || newCharacteristic.getType() != oldCharacteristic.getType()) {
         // characteristic is gone or has completely changed; drop all subscriptions for it
-        LOGGER.debug(
+        LOGGER.trace(
             "{}:{} ({}) has gone missing; dropping subscriptions.",
             subscribers.aid,
             subscribers.iid,
@@ -199,7 +199,7 @@ public class SubscriptionManager {
       } else if (newCharacteristic != oldCharacteristic) {
         EventableCharacteristic newEventableCharacteristic =
             (EventableCharacteristic) newCharacteristic;
-        LOGGER.debug(
+        LOGGER.trace(
             "{}:{} has been replaced by a compatible characteristic; re-connecting subscriptions",
             subscribers.aid,
             subscribers.iid);
@@ -242,16 +242,16 @@ public class SubscriptionManager {
 
   /** Remove all existing subscriptions */
   public synchronized void removeAll() {
-    LOGGER.debug("Removing {} reverse connections from subscription manager", reverse.size());
+    LOGGER.trace("Removing {} reverse connections from subscription manager", reverse.size());
     Iterator<Map.Entry<HomekitClientConnection, Set<EventableCharacteristic>>> i =
         reverse.entrySet().iterator();
     while (i.hasNext()) {
       Map.Entry<HomekitClientConnection, Set<EventableCharacteristic>> entry = i.next();
       HomekitClientConnection connection = entry.getKey();
-      LOGGER.debug("Removing connection {}", connection.hashCode());
+      LOGGER.trace("Removing connection {}", connection.hashCode());
       i.remove();
       removeConnection(connection, entry.getValue());
     }
-    LOGGER.debug("Subscription sizes are {} and {}", reverse.size(), subscriptions.size());
+    LOGGER.trace("Subscription sizes are {} and {}", reverse.size(), subscriptions.size());
   }
 }

--- a/src/main/java/io/github/hapjava/server/impl/connections/SubscriptionManager.java
+++ b/src/main/java/io/github/hapjava/server/impl/connections/SubscriptionManager.java
@@ -1,15 +1,18 @@
 package io.github.hapjava.server.impl.connections;
 
+import io.github.hapjava.characteristics.Characteristic;
 import io.github.hapjava.characteristics.EventableCharacteristic;
+import io.github.hapjava.server.impl.HomekitRegistry;
 import io.github.hapjava.server.impl.http.HomekitClientConnection;
 import io.github.hapjava.server.impl.http.HttpResponse;
 import io.github.hapjava.server.impl.json.EventController;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,12 +20,22 @@ public class SubscriptionManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionManager.class);
 
-  private final ConcurrentMap<EventableCharacteristic, Set<HomekitClientConnection>> subscriptions =
-      new ConcurrentHashMap<>();
-  private final ConcurrentMap<HomekitClientConnection, Set<EventableCharacteristic>> reverse =
-      new ConcurrentHashMap<>();
-  private final ConcurrentMap<HomekitClientConnection, ArrayList<PendingNotification>>
-      pendingNotifications = new ConcurrentHashMap<>();
+  private static class ConnectionsWithIds {
+    Set<HomekitClientConnection> connections;
+    int aid, iid;
+
+    ConnectionsWithIds(int aid, int iid) {
+      this.aid = aid;
+      this.iid = iid;
+      this.connections = new HashSet<>();
+    }
+  }
+
+  private final Map<EventableCharacteristic, ConnectionsWithIds> subscriptions = new HashMap<>();
+  private final Map<HomekitClientConnection, Set<EventableCharacteristic>> reverse =
+      new HashMap<>();
+  private final Map<HomekitClientConnection, List<PendingNotification>> pendingNotifications =
+      new HashMap<>();
   private int nestedBatches = 0;
 
   public synchronized void addSubscription(
@@ -31,64 +44,75 @@ public class SubscriptionManager {
       EventableCharacteristic characteristic,
       HomekitClientConnection connection) {
     synchronized (this) {
-      if (!subscriptions.containsKey(characteristic)) {
-        subscriptions.putIfAbsent(characteristic, newSet());
+      ConnectionsWithIds subscribers;
+      if (subscriptions.containsKey(characteristic)) {
+        subscribers = subscriptions.get(characteristic);
+      } else {
+        subscribers = new ConnectionsWithIds(aid, iid);
+        subscriptions.put(characteristic, subscribers);
+        subscribe(aid, iid, characteristic);
       }
-      subscriptions.get(characteristic).add(connection);
-      if (subscriptions.get(characteristic).size() == 1) {
-        characteristic.subscribe(
-            () -> {
-              publish(aid, iid, characteristic);
-            });
-      }
+      subscribers.connections.add(connection);
 
       if (!reverse.containsKey(connection)) {
-        reverse.putIfAbsent(connection, newSet());
+        reverse.put(connection, new HashSet<>());
       }
       reverse.get(connection).add(characteristic);
-      LOGGER.trace(
-          "Added subscription to " + characteristic.getClass() + " for " + connection.hashCode());
+      LOGGER.debug(
+          "Added subscription to {}:{} ({}) for {}",
+          aid,
+          iid,
+          characteristic.getClass().getSimpleName(),
+          connection.hashCode());
     }
   }
 
   public synchronized void removeSubscription(
       EventableCharacteristic characteristic, HomekitClientConnection connection) {
-    Set<HomekitClientConnection> subscriptions = this.subscriptions.get(characteristic);
-    if (subscriptions != null) {
-      subscriptions.remove(connection);
-      if (subscriptions.size() == 0) {
+    ConnectionsWithIds subscribers = subscriptions.get(characteristic);
+    if (subscribers != null) {
+      subscribers.connections.remove(connection);
+      if (subscribers.connections.isEmpty()) {
+        LOGGER.debug("Unsubscribing from characteristic as all subscriptions are closed");
         characteristic.unsubscribe();
+        subscriptions.remove(characteristic);
       }
+
+      // Remove pending notifications for this no-longer-subscribed characteristic
+      List<PendingNotification> connectionNotifications = pendingNotifications.get(connection);
+      if (connectionNotifications != null) {
+        connectionNotifications.removeIf(n -> n.aid == subscribers.aid && n.iid == subscribers.iid);
+        if (connectionNotifications.isEmpty()) pendingNotifications.remove(connection);
+      }
+
+      LOGGER.debug(
+          "Removed subscription from {}:{} ({}) for {}",
+          subscribers.aid,
+          subscribers.iid,
+          characteristic.getClass().getSimpleName(),
+          connection.hashCode());
     }
 
     Set<EventableCharacteristic> reverse = this.reverse.get(connection);
     if (reverse != null) {
       reverse.remove(characteristic);
+      if (reverse.isEmpty()) this.reverse.remove(connection);
     }
-    LOGGER.trace(
-        "Removed subscription to " + characteristic.getClass() + " for " + connection.hashCode());
   }
 
   public synchronized void removeConnection(HomekitClientConnection connection) {
-    Set<EventableCharacteristic> characteristics = reverse.remove(connection);
+    removeConnection(connection, reverse.remove(connection));
+  }
+
+  private void removeConnection(
+      HomekitClientConnection connection, Set<EventableCharacteristic> characteristics) {
     pendingNotifications.remove(connection);
     if (characteristics != null) {
       for (EventableCharacteristic characteristic : characteristics) {
-        Set<HomekitClientConnection> characteristicSubscriptions =
-            subscriptions.get(characteristic);
-        characteristicSubscriptions.remove(connection);
-        if (characteristicSubscriptions.isEmpty()) {
-          LOGGER.trace("Unsubscribing from characteristic as all subscriptions are closed");
-          characteristic.unsubscribe();
-          subscriptions.remove(characteristic);
-        }
+        removeSubscription(characteristic, connection);
       }
     }
-    LOGGER.trace("Removed connection {}", connection.hashCode());
-  }
-
-  private <T> Set<T> newSet() {
-    return Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>());
+    LOGGER.debug("Removed connection {}", connection.hashCode());
   }
 
   public synchronized void batchUpdate() {
@@ -96,31 +120,35 @@ public class SubscriptionManager {
   }
 
   public synchronized void completeUpdateBatch() {
-    if (--this.nestedBatches == 0 && !pendingNotifications.isEmpty()) {
-      LOGGER.trace("Publishing batched changes");
-      for (ConcurrentMap.Entry<HomekitClientConnection, ArrayList<PendingNotification>> entry :
-          pendingNotifications.entrySet()) {
-        try {
-          HttpResponse message = new EventController().getMessage(entry.getValue());
-          entry.getKey().outOfBand(message);
-        } catch (Exception e) {
-          LOGGER.warn("Failed to create new event message", e);
-        }
+    if (--this.nestedBatches == 0) flushUpdateBatch();
+  }
+
+  private void flushUpdateBatch() {
+    if (pendingNotifications.isEmpty()) return;
+
+    LOGGER.trace("Publishing batched changes");
+    for (Map.Entry<HomekitClientConnection, List<PendingNotification>> entry :
+        pendingNotifications.entrySet()) {
+      try {
+        HttpResponse message = new EventController().getMessage(entry.getValue());
+        entry.getKey().outOfBand(message);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to create new event message", e);
       }
-      pendingNotifications.clear();
     }
+    pendingNotifications.clear();
   }
 
   public synchronized void publish(int accessoryId, int iid, EventableCharacteristic changed) {
-    final Set<HomekitClientConnection> subscribers = subscriptions.get(changed);
-    if ((subscribers == null) || (subscribers.isEmpty())) {
-      LOGGER.debug("No subscribers to characteristic {} at accessory {} ", changed, accessoryId);
+    final ConnectionsWithIds subscribers = subscriptions.get(changed);
+    if (subscribers == null || subscribers.connections.isEmpty()) {
+      LOGGER.trace("No subscribers to characteristic {} at accessory {} ", changed, accessoryId);
       return; // no subscribers
     }
     if (nestedBatches != 0) {
       LOGGER.trace("Batching change for accessory {} and characteristic {} " + accessoryId, iid);
       PendingNotification notification = new PendingNotification(accessoryId, iid, changed);
-      for (HomekitClientConnection connection : subscribers) {
+      for (HomekitClientConnection connection : subscribers.connections) {
         if (!pendingNotifications.containsKey(connection)) {
           pendingNotifications.put(connection, new ArrayList<PendingNotification>());
         }
@@ -132,7 +160,7 @@ public class SubscriptionManager {
     try {
       HttpResponse message = new EventController().getMessage(accessoryId, iid, changed);
       LOGGER.trace("Publishing change for " + accessoryId);
-      for (HomekitClientConnection connection : subscribers) {
+      for (HomekitClientConnection connection : subscribers.connections) {
         connection.outOfBand(message);
       }
     } catch (Exception e) {
@@ -140,15 +168,90 @@ public class SubscriptionManager {
     }
   }
 
-  /** Remove all existing subscriptions */
-  public void removeAll() {
-    LOGGER.trace("Removing {} reverse connections from subscription manager", reverse.size());
-    Iterator<HomekitClientConnection> i = reverse.keySet().iterator();
+  /**
+   * The accessory registry has changed; go through all subscriptions and link to any new/changed
+   * characteristics
+   */
+  public synchronized void resync(HomekitRegistry registry) {
+    LOGGER.debug("Resyncing subscriptions");
+    flushUpdateBatch();
+
+    Map<EventableCharacteristic, ConnectionsWithIds> newSubscriptions = new HashMap<>();
+    Iterator<Map.Entry<EventableCharacteristic, ConnectionsWithIds>> i =
+        subscriptions.entrySet().iterator();
     while (i.hasNext()) {
-      HomekitClientConnection connection = i.next();
-      LOGGER.trace("Removing connection {}", connection.hashCode());
-      removeConnection(connection);
+      Map.Entry<EventableCharacteristic, ConnectionsWithIds> entry = i.next();
+      EventableCharacteristic oldCharacteristic = entry.getKey();
+      ConnectionsWithIds subscribers = entry.getValue();
+      Characteristic newCharacteristic =
+          registry.getCharacteristics(subscribers.aid).get(subscribers.iid);
+      if (newCharacteristic == null || newCharacteristic.getType() != oldCharacteristic.getType()) {
+        // characteristic is gone or has completely changed; drop all subscriptions for it
+        LOGGER.debug(
+            "{}:{} ({}) has gone missing; dropping subscriptions.",
+            subscribers.aid,
+            subscribers.iid,
+            oldCharacteristic.getClass().getSimpleName());
+        i.remove();
+        for (HomekitClientConnection conn : subscribers.connections) {
+          removeSubscription(oldCharacteristic, conn);
+        }
+      } else if (newCharacteristic != oldCharacteristic) {
+        EventableCharacteristic newEventableCharacteristic =
+            (EventableCharacteristic) newCharacteristic;
+        LOGGER.debug(
+            "{}:{} has been replaced by a compatible characteristic; re-connecting subscriptions",
+            subscribers.aid,
+            subscribers.iid);
+        // characteristic has been replaced by another instance of the same thing;
+        // re-connect subscriptions
+        i.remove();
+        oldCharacteristic.unsubscribe();
+        subscribe(subscribers.aid, subscribers.iid, newEventableCharacteristic);
+        // we can't replace the key, and we can't add to the map while we're iterating,
+        // so save it off to a temporary map that we'll add them all at the end
+        newSubscriptions.put(newEventableCharacteristic, subscribers);
+
+        for (HomekitClientConnection conn : subscribers.connections) {
+          Set<EventableCharacteristic> subscribedCharacteristics = reverse.get(conn);
+          subscribedCharacteristics.remove(oldCharacteristic);
+          subscribedCharacteristics.add(newEventableCharacteristic);
+
+          // and also update references for any pending notifications, so they'll get the proper
+          // value
+          List<PendingNotification> connectionPendingNotifications = pendingNotifications.get(conn);
+          if (connectionPendingNotifications != null) {
+            for (PendingNotification notification : connectionPendingNotifications) {
+              if (notification.characteristic == oldCharacteristic) {
+                notification.characteristic = newEventableCharacteristic;
+              }
+            }
+          }
+        }
+      }
     }
-    LOGGER.trace("Subscription sizes are {} and {}", reverse.size(), subscriptions.size());
+    subscriptions.putAll(newSubscriptions);
+  }
+
+  private void subscribe(int aid, int iid, EventableCharacteristic characteristic) {
+    characteristic.subscribe(
+        () -> {
+          publish(aid, iid, characteristic);
+        });
+  }
+
+  /** Remove all existing subscriptions */
+  public synchronized void removeAll() {
+    LOGGER.debug("Removing {} reverse connections from subscription manager", reverse.size());
+    Iterator<Map.Entry<HomekitClientConnection, Set<EventableCharacteristic>>> i =
+        reverse.entrySet().iterator();
+    while (i.hasNext()) {
+      Map.Entry<HomekitClientConnection, Set<EventableCharacteristic>> entry = i.next();
+      HomekitClientConnection connection = entry.getKey();
+      LOGGER.debug("Removing connection {}", connection.hashCode());
+      i.remove();
+      removeConnection(connection, entry.getValue());
+    }
+    LOGGER.debug("Subscription sizes are {} and {}", reverse.size(), subscriptions.size());
   }
 }

--- a/src/main/java/io/github/hapjava/server/impl/json/EventController.java
+++ b/src/main/java/io/github/hapjava/server/impl/json/EventController.java
@@ -4,7 +4,7 @@ import io.github.hapjava.characteristics.EventableCharacteristic;
 import io.github.hapjava.server.impl.connections.PendingNotification;
 import io.github.hapjava.server.impl.http.HttpResponse;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
+import java.util.List;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
@@ -34,7 +34,7 @@ public class EventController {
     }
   }
 
-  public HttpResponse getMessage(ArrayList<PendingNotification> notifications) throws Exception {
+  public HttpResponse getMessage(List<PendingNotification> notifications) throws Exception {
     JsonArrayBuilder characteristics = Json.createArrayBuilder();
 
     for (PendingNotification notification : notifications) {


### PR DESCRIPTION
but the connection is _not_ torn down

also add the ability to modify accessories in a batch without having to regenerate all AIDs and IIDs (and other temporary data structures) at each intermediate step. You must use this mechanism if you plan on replacing an existing accessory with an equivalent one, but want to keep subscriptions intact.
