### PR TITLE
check for AccessoryInformationService by UUID, not by class

### DIFF
--- a/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitRegistry.java
@@ -43,7 +43,8 @@ public class HomekitRegistry {
       try {
         newServices = new ArrayList<>(2);
         Collection<Service> services = accessory.getServices();
-        if (!services.stream().anyMatch(s -> s instanceof AccessoryInformationService)) {
+        if (!services.stream()
+            .anyMatch(s -> s.getType().equals(AccessoryInformationService.TYPE))) {
           newServices.add(new AccessoryInformationService(accessory));
         }
         for (Service service : services) {

--- a/src/main/java/io/github/hapjava/services/impl/AccessoryInformationService.java
+++ b/src/main/java/io/github/hapjava/services/impl/AccessoryInformationService.java
@@ -14,6 +14,7 @@ import io.github.hapjava.characteristics.impl.common.NameCharacteristic;
 
 /** Accessory Information service. */
 public class AccessoryInformationService extends AbstractServiceImpl {
+  public static final String TYPE = "0000003E-0000-1000-8000-0026BB765291";
 
   public AccessoryInformationService(
       IdentifyCharacteristic identify,
@@ -22,7 +23,7 @@ public class AccessoryInformationService extends AbstractServiceImpl {
       NameCharacteristic name,
       SerialNumberCharacteristic serialNumber,
       FirmwareRevisionCharacteristic firmwareRevision) {
-    super("0000003E-0000-1000-8000-0026BB765291");
+    super(TYPE);
     addCharacteristic(identify);
     addCharacteristic(manufacturer);
     addCharacteristic(model);


### PR DESCRIPTION
in case someone is using some form of decorator or replacement class, but is still exposing the proper type
