### PR TITLE
TelevisionAccessory Related Fixes

### DIFF
--- a/src/main/java/io/github/hapjava/characteristics/impl/television/RemoteKeyEnum.java
+++ b/src/main/java/io/github/hapjava/characteristics/impl/television/RemoteKeyEnum.java
@@ -18,7 +18,7 @@ public enum RemoteKeyEnum implements CharacteristicEnum {
   BACK(9),
   EXIT(10),
   PLAY_PAUSE(11),
-  INFO(115);
+  INFO(15);
 
   private static final Map<Integer, RemoteKeyEnum> reverse;
 

--- a/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
@@ -117,6 +117,15 @@ public class HomekitServer {
       return new HomekitStandaloneAccessoryServer(accessory, http, localAddress, authInfo);
     }
   }
+  public HomekitStandaloneAccessoryServer createStandaloneAccessory(
+      HomekitAuthInfo authInfo, HomekitAccessory accessory, int category)
+      throws IOException, ExecutionException, InterruptedException {
+    if (jmdns != null) {
+      return new HomekitStandaloneAccessoryServer(accessory, http, jmdns, authInfo, category);
+    } else {
+      return new HomekitStandaloneAccessoryServer(accessory, http, localAddress, authInfo, category);
+    }
+  }
 
   /**
    * Creates a bridge accessory, capable of holding multiple child accessories. This has the

--- a/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
@@ -40,6 +40,28 @@ public class HomekitStandaloneAccessoryServer {
     root = new HomekitRoot(accessory.getName().get(), webHandler, jmdns, authInfo);
     root.addAccessory(accessory);
   }
+  
+  HomekitStandaloneAccessoryServer(
+      HomekitAccessory accessory,
+      HomekitWebHandler webHandler,
+      InetAddress localhost,
+      HomekitAuthInfo authInfo,
+      int category)
+      throws UnknownHostException, IOException, ExecutionException, InterruptedException {
+    root = new HomekitRoot(accessory.getName().get(), category, webHandler, localhost, authInfo);
+    root.addAccessory(accessory);
+  }
+
+  HomekitStandaloneAccessoryServer(
+      HomekitAccessory accessory,
+      HomekitWebHandler webHandler,
+      JmDNS jmdns,
+      HomekitAuthInfo authInfo,
+      int category)
+      throws UnknownHostException, IOException, ExecutionException, InterruptedException {
+    root = new HomekitRoot(accessory.getName().get(), category, webHandler, jmdns, authInfo);
+    root.addAccessory(accessory);
+  }
 
   /** Begins advertising and handling requests for this accessory. */
   public void start() {


### PR DESCRIPTION
This pull requests fixes two issues:

- RemoteKeyEnum code for Info button is incorrect. Release version shows code 115, actual code is 15. Tested on IOS 16 and 15.
- Adds support for accessory category on standalone server. previously category was implemented for a bridge, but not for standalone accessories. 