### PR TITLE
Removed 2 unnecessary stubbings in HomekitRootTest.java

### DIFF
--- a/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitServer.java
@@ -117,13 +117,15 @@ public class HomekitServer {
       return new HomekitStandaloneAccessoryServer(accessory, http, localAddress, authInfo);
     }
   }
+
   public HomekitStandaloneAccessoryServer createStandaloneAccessory(
       HomekitAuthInfo authInfo, HomekitAccessory accessory, int category)
       throws IOException, ExecutionException, InterruptedException {
     if (jmdns != null) {
       return new HomekitStandaloneAccessoryServer(accessory, http, jmdns, authInfo, category);
     } else {
-      return new HomekitStandaloneAccessoryServer(accessory, http, localAddress, authInfo, category);
+      return new HomekitStandaloneAccessoryServer(
+          accessory, http, localAddress, authInfo, category);
     }
   }
 

--- a/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
+++ b/src/main/java/io/github/hapjava/server/impl/HomekitStandaloneAccessoryServer.java
@@ -40,7 +40,7 @@ public class HomekitStandaloneAccessoryServer {
     root = new HomekitRoot(accessory.getName().get(), webHandler, jmdns, authInfo);
     root.addAccessory(accessory);
   }
-  
+
   HomekitStandaloneAccessoryServer(
       HomekitAccessory accessory,
       HomekitWebHandler webHandler,

--- a/src/test/java/io/github/hapjava/server/impl/FourthHomekitRootTest.java
+++ b/src/test/java/io/github/hapjava/server/impl/FourthHomekitRootTest.java
@@ -1,9 +1,6 @@
 package io.github.hapjava.server.impl;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.hapjava.accessories.HomekitAccessory;
@@ -11,11 +8,11 @@ import io.github.hapjava.server.HomekitAccessoryCategories;
 import io.github.hapjava.server.HomekitAuthInfo;
 import io.github.hapjava.server.HomekitWebHandler;
 import io.github.hapjava.server.impl.jmdns.JmdnsHomekitAdvertiser;
-import java.util.concurrent.CompletableFuture;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class HomekitRootTest {
+public class FourthHomekitRootTest {
 
   private HomekitAccessory accessory;
   private HomekitRoot root;
@@ -33,7 +30,6 @@ public class HomekitRootTest {
     accessory = mock(HomekitAccessory.class);
     when(accessory.getId()).thenReturn(2);
     webHandler = mock(HomekitWebHandler.class);
-    when(webHandler.start(any())).thenReturn(CompletableFuture.completedFuture(PORT));
     advertiser = mock(JmdnsHomekitAdvertiser.class);
     authInfo = mock(HomekitAuthInfo.class);
     root =
@@ -41,17 +37,19 @@ public class HomekitRootTest {
   }
 
   @Test
-  public void testAddAccessoryDoesntResetWeb() {
-    root.start();
+  public void verifyRegistryAdded() throws Exception {
     root.addAccessory(accessory);
-    verify(webHandler, never()).resetConnections();
+    Assert.assertTrue(
+        "Registry does not contain accessory",
+        root.getRegistry().getAccessories().contains(accessory));
   }
 
   @Test
-  public void testRemoveAccessoryDoesntResetWeb() {
+  public void verifyRegistryRemoved() throws Exception {
     root.addAccessory(accessory);
-    root.start();
     root.removeAccessory(accessory);
-    verify(webHandler, never()).resetConnections();
+    Assert.assertFalse(
+        "Registry still contains accessory",
+        root.getRegistry().getAccessories().contains(accessory));
   }
 }

--- a/src/test/java/io/github/hapjava/server/impl/ThirdHomekitRootTest.java
+++ b/src/test/java/io/github/hapjava/server/impl/ThirdHomekitRootTest.java
@@ -1,9 +1,6 @@
 package io.github.hapjava.server.impl;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.hapjava.accessories.HomekitAccessory;
@@ -11,11 +8,10 @@ import io.github.hapjava.server.HomekitAccessoryCategories;
 import io.github.hapjava.server.HomekitAuthInfo;
 import io.github.hapjava.server.HomekitWebHandler;
 import io.github.hapjava.server.impl.jmdns.JmdnsHomekitAdvertiser;
-import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 
-public class HomekitRootTest {
+public class ThirdHomekitRootTest {
 
   private HomekitAccessory accessory;
   private HomekitRoot root;
@@ -31,27 +27,16 @@ public class HomekitRootTest {
   @Before
   public void setup() throws Exception {
     accessory = mock(HomekitAccessory.class);
-    when(accessory.getId()).thenReturn(2);
     webHandler = mock(HomekitWebHandler.class);
-    when(webHandler.start(any())).thenReturn(CompletableFuture.completedFuture(PORT));
     advertiser = mock(JmdnsHomekitAdvertiser.class);
     authInfo = mock(HomekitAuthInfo.class);
     root =
         new HomekitRoot(LABEL, HomekitAccessoryCategories.OTHER, webHandler, authInfo, advertiser);
   }
 
-  @Test
-  public void testAddAccessoryDoesntResetWeb() {
-    root.start();
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testAddIndexOneAccessory() throws Exception {
+    when(accessory.getId()).thenReturn(1);
     root.addAccessory(accessory);
-    verify(webHandler, never()).resetConnections();
-  }
-
-  @Test
-  public void testRemoveAccessoryDoesntResetWeb() {
-    root.addAccessory(accessory);
-    root.start();
-    root.removeAccessory(accessory);
-    verify(webHandler, never()).resetConnections();
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

Please confirm that you've done the following when opening a new pull request:

  - [ ] For fixes and other improvements, please reference the GitHub issue that your change addresses.
  - [ ] For fixes, optimizations and new features, please add an entry to the CHANGES.md file.
  - [x] Run mvn compile before committing, so that the auto-code formatter will format your changes consistently with the rest of the project.
  
In our analysis of the project, we observed that

1) 1 stubbing that stubbed `getId` is created in `HomekitRootTest.setup` but never executed in 5 tests `HomekitRootTest.testWebHandlerStarts`, `HomekitRootTest.testWebHandlerStops`, `HomekitRootTest.testAdvertiserStarts`, `HomekitRootTest.testAdvertiserStops`, `HomekitRootTest.testAddIndexOneAccessory`;
2)  1 stubbing that stubbed `start`is created in `HomekitRootTest.setup` but never executed in 3 tests`HomekitRootTest.verifyRegistryAdded`,`HomekitRootTest.verifyRegistryRemoved`, `HomekitRootTest.testAddIndexOneAccessory`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.